### PR TITLE
Merkle functionality, refactoring and continence functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "snark-vrf"
+name = "ring-vrf"
 version = "0.1.0"
-authors = ["Sergey Vasilyev <swasilyev@gmail.com>"]
+description = "Ring VRF implementation using zkSNARKs."
+authors = ["Sergey Vasilyev <swasilyev@gmail.com>", "Wei Tang <hi@that.world>"]
 edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+license = "MIT"
 
 [dependencies]
 ff = { git = "https://github.com/zcash/librustzcash" }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # ring-vrf
+
+Ring VRF implementation using zkSNARKs.

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -18,31 +18,31 @@ use bellman::gadgets::Assignment;
 use bellman::gadgets::test::TestConstraintSystem;
 use pairing::bls12_381::Bls12;
 
-// A circuit for proving that the given vrf_output is valid for the given vrf_input under
-// a key from the predefined set. It formalizes the following language:
-// {(VRF_INPUT, VRF_OUTPUT, set) | VRF_OUTPUT = vrf(sk, VRF_INPUT), PK = derive(sk) and  PK is in set }, where:
-// - sk, PK is an elliptic curve keypair, thus PK is a point, sk is a scalar and derive(sk) = sk * B, for a predefined base pont B
-// - VRF_INPUT and VRF_OUTPUT are elliptic curve points, and vrf(sk, VRF_INPUT) = sk * VRF_INPUT
-// - set //TODO
-
-// These are the values that are required to construct the circuit and populate all the wires.
-// They are defined as Options as for CRS generation only circuit structure is relevant,
-// not the wires' assignments, so knowing the types is enough.
+/// A circuit for proving that the given vrf_output is valid for the given vrf_input under
+/// a key from the predefined set. It formalizes the following language:
+///
+/// {(VRF_INPUT, VRF_OUTPUT, set) | VRF_OUTPUT = vrf(sk, VRF_INPUT), PK = derive(sk) and  PK is in set }, where:
+/// - sk, PK is an elliptic curve keypair, thus PK is a point, sk is a scalar and derive(sk) = sk * B, for a predefined base pont B
+/// - VRF_INPUT and VRF_OUTPUT are elliptic curve points, and vrf(sk, VRF_INPUT) = sk * VRF_INPUT
+/// - set // TODO
+///
+/// These are the values that are required to construct the circuit and populate all the wires.
+/// They are defined as Options as for CRS generation only circuit structure is relevant,
+/// not the wires' assignments, so knowing the types is enough.
 pub struct Ring<'a, E: JubjubEngine> { // TODO: name
-
-    // Jubjub curve parameters.
+    /// Jubjub curve parameters.
     pub params: &'a E::Params,
 
-    // The secret key, an element of Jubjub scalar field.
+    /// The secret key, an element of Jubjub scalar field.
     pub sk: Option<E::Fs>,
 
-    // The VRF input, a point in Jubjub prime order subgroup.
+    /// The VRF input, a point in Jubjub prime order subgroup.
     pub vrf_input: Option<edwards::Point<E, PrimeOrder>>,
 
-    // The authentication path of the public key x-coordinate in the Merkle tree,
-    // the element of Jubjub base field.
-    // This is enough to build the root as the base point is hardcoded in the circuit in the lookup tables,
-    // so we can restore the public key from the secret key.
+    /// The authentication path of the public key x-coordinate in the Merkle tree,
+    /// the element of Jubjub base field.
+    /// This is enough to build the root as the base point is hardcoded in the circuit in the lookup tables,
+    /// so we can restore the public key from the secret key.
     pub auth_path: Vec<Option<(E::Fr, bool)>>,
 }
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,21 +1,19 @@
 use bellman::groth16::{generate_random_parameters, Parameters,};
 use bellman::SynthesisError;
-use pairing::bls12_381::Bls12;
-use zcash_primitives::jubjub::JubjubBls12;
+use zcash_primitives::jubjub::JubjubEngine;
 use rand_core::OsRng;
-use crate::Ring;
+use crate::{Ring, Params};
 
 /// Generates structured (meaning circuit-depending) Groth16
 /// CRS (that comprises proving and verificaton keys) over BLS12-381
 /// for the circuit defined in circuit.rs using OS RNG.
-pub fn generate_crs() -> Result<Parameters<Bls12>, SynthesisError> {
-    let params = &JubjubBls12::new();
+pub fn generate_crs<E: JubjubEngine>(params: &Params<E>) -> Result<Parameters<E>, SynthesisError> {
     let rng = &mut OsRng;
     let circuit = Ring {
         params,
         sk: None,
         vrf_input: None,
-        auth_path: vec![None; 10],
+        auth_path: None,
     };
     generate_random_parameters(circuit, rng)
 }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -3,20 +3,20 @@ use bellman::SynthesisError;
 use pairing::bls12_381::{Bls12, Fr,};
 use ff::Field;
 use zcash_primitives::jubjub::JubjubBls12;
-use super::circuit::Ring;
-use rand_core::{RngCore, OsRng};
+use rand_core::OsRng;
+use crate::{Ring, PathDirection};
 
-// Generates structured (meaning circuit-depending) Groth16
-// CRS (that comprises proving and verificaton keys) over BLS12-381
-// for the circuit defined in circuit.rs using OS RNG.
+/// Generates structured (meaning circuit-depending) Groth16
+/// CRS (that comprises proving and verificaton keys) over BLS12-381
+/// for the circuit defined in circuit.rs using OS RNG.
 pub fn generate_crs() -> Result<Parameters<Bls12>, SynthesisError> {
     let params = &JubjubBls12::new();
-    let mut rng = OsRng;
+    let rng = &mut OsRng;
     let circuit = Ring {
         params,
         sk: None,
         vrf_input: None,
-        auth_path: vec![Some((Fr::random(&mut rng), rng.next_u32() % 2 != 0)); 10],
+        auth_path: vec![(Fr::random(rng), PathDirection::random(rng)); 10],
     };
-    generate_random_parameters(circuit, &mut rng)
+    generate_random_parameters(circuit, rng)
 }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,10 +1,9 @@
 use bellman::groth16::{generate_random_parameters, Parameters,};
 use bellman::SynthesisError;
-use pairing::bls12_381::{Bls12, Fr,};
-use ff::Field;
+use pairing::bls12_381::Bls12;
 use zcash_primitives::jubjub::JubjubBls12;
 use rand_core::OsRng;
-use crate::{Ring, PathDirection};
+use crate::Ring;
 
 /// Generates structured (meaning circuit-depending) Groth16
 /// CRS (that comprises proving and verificaton keys) over BLS12-381
@@ -16,7 +15,7 @@ pub fn generate_crs() -> Result<Parameters<Bls12>, SynthesisError> {
         params,
         sk: None,
         vrf_input: None,
-        auth_path: vec![(Fr::random(rng), PathDirection::random(rng)); 10],
+        auth_path: vec![None; 10],
     };
     generate_random_parameters(circuit, rng)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub use crate::circuit::Ring;
 pub use crate::merkle::{MerkleSelection, AuthPath, AuthRoot, AuthPathPoint, auth_hash};
 pub use crate::generator::generate_crs;
 pub use crate::prover::prove;
-pub use crate::verifier::verify;
+pub use crate::verifier::{verify, verify_prepared};
 
 use zcash_primitives::jubjub::JubjubEngine;
 
@@ -26,7 +26,7 @@ mod tests {
     use std::time::SystemTime;
 
     use ff::Field;
-    use bellman::groth16::{prepare_verifying_key, Parameters};
+    use bellman::groth16::Parameters;
     use zcash_primitives::jubjub::{JubjubBls12, JubjubParams, FixedGenerators, fs, edwards};
     use pairing::bls12_381::Bls12;
     use rand_core::SeedableRng;
@@ -80,8 +80,7 @@ mod tests {
         let proof = proof.unwrap();
 
         let t = SystemTime::now();
-        let pvk = prepare_verifying_key::<Bls12>(&crs.vk);
-        let valid = verifier::verify(&pvk, proof, vrf_base, vrf_output, auth_root);
+        let valid = verifier::verify(&crs, proof, vrf_base, vrf_output, auth_root);
         println!("verification = {}", t.elapsed().unwrap().as_millis());
         assert_eq!(valid.unwrap(), true);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,20 @@ mod prover;
 mod verifier;
 
 pub use crate::circuit::Ring;
-pub use crate::merkle::{aggregated_pkx, PathDirection};
+pub use crate::merkle::{MerkleSelection, AuthPath, AuthRoot, AuthPathPoint, auth_hash};
 pub use crate::generator::generate_crs;
 pub use crate::prover::prove;
 pub use crate::verifier::verify;
+
+use zcash_primitives::jubjub::JubjubEngine;
+
+/// Configuration parameters for the system.
+pub struct Params<E: JubjubEngine> {
+    /// Engine parameters.
+    pub engine: E::Params,
+    /// Authentication depth.
+    pub auth_depth: usize,
+}
 
 #[cfg(test)]
 mod tests {
@@ -18,7 +28,7 @@ mod tests {
     use ff::Field;
     use bellman::groth16::{prepare_verifying_key, Parameters};
     use zcash_primitives::jubjub::{JubjubBls12, JubjubParams, FixedGenerators, fs, edwards};
-    use pairing::bls12_381::{Bls12, Fr};
+    use pairing::bls12_381::Bls12;
     use rand_core::SeedableRng;
     use rand_xorshift::XorShiftRng;
 
@@ -26,19 +36,22 @@ mod tests {
 
     #[test]
     fn test_completeness() {
-        let rng = &mut XorShiftRng::from_seed([
-            0x58, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
-            0xe5,
-        ]);
+        let params = Params::<Bls12> {
+            engine: JubjubBls12::new(),
+            auth_depth: 10,
+        };
 
-        let params = &JubjubBls12::new();
+        let rng = &mut XorShiftRng::from_seed([
+            0x58, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d,
+            0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc, 0xe5,
+        ]);
 
         let crs = match File::open("crs") {
             Ok(f) => Parameters::<Bls12>::read(f, false).expect("can't read CRS"),
             Err(_) => {
                 let f = File::create("crs").unwrap();
                 let t = SystemTime::now();
-                let c = generator::generate_crs().expect("can't generate CRS");
+                let c = generator::generate_crs(&params).expect("can't generate CRS");
                 println!("generation = {}", t.elapsed().unwrap().as_secs());
                 c.write(&f).unwrap();
                 c
@@ -46,32 +59,29 @@ mod tests {
         };
 
         // Jubjub generator point // TODO: prime or---
-        let base_point = params.generator(FixedGenerators::SpendingKeyGenerator);
+        let base_point = params.engine.generator(FixedGenerators::SpendingKeyGenerator);
 
         // validator's secret key, an element of Jubjub scalar field
         let sk = fs::Fs::random(rng);
 
         // validator's public key, a point on Jubjub
-        let pk = base_point.mul(sk, params);
+        let pk = base_point.mul(sk, &params.engine);
 
         // VRF base point
-        let vrf_base = edwards::Point::rand(rng, params).mul_by_cofactor(params);
+        let vrf_base = edwards::Point::rand(rng, &params.engine).mul_by_cofactor(&params.engine);
+        let vrf_output = vrf_base.mul(sk, &params.engine);
 
-        let vrf_output = vrf_base.mul(sk, params);
-
-        let tree_depth = 10;
-        let auth_path = vec![(Fr::random(rng), PathDirection::random(rng)); tree_depth];
-
-        let apkx = aggregated_pkx::<Bls12>(params, pk.to_xy().0, &auth_path);
+        let auth_path = AuthPath::random(params.auth_depth, rng);
+        let auth_root = AuthRoot::from_proof(&auth_path, &pk.to_xy().0, &params);
 
         let t = SystemTime::now();
-        let proof = prover::prove(params, &crs, sk, vrf_base.clone(), auth_path.clone());
+        let proof = prover::prove::<Bls12>(&crs, sk, vrf_base.clone(), auth_path.clone(), &params);
         println!("proving = {}", t.elapsed().unwrap().as_millis());
         let proof = proof.unwrap();
 
         let t = SystemTime::now();
         let pvk = prepare_verifying_key::<Bls12>(&crs.vk);
-        let valid = verifier::verify(&pvk, proof, vrf_base, vrf_output, apkx);
+        let valid = verifier::verify(&pvk, proof, vrf_base, vrf_output, auth_root);
         println!("verification = {}", t.elapsed().unwrap().as_millis());
         assert_eq!(valid.unwrap(), true);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,98 +1,78 @@
-use std::time::SystemTime;
-use std::fs::File;
-use bellman::groth16::{Parameters, prepare_verifying_key};
-use zcash_primitives::pedersen_hash;
-use ff::BitIterator;
+mod merkle;
+mod circuit;
+mod generator;
+mod prover;
+mod verifier;
 
-pub mod circuit;
-pub mod generator;
-pub mod prover;
-pub mod verifier;
+pub use crate::circuit::Ring;
+pub use crate::merkle::{aggregated_pkx, PathDirection};
+pub use crate::generator::generate_crs;
+pub use crate::prover::prove;
+pub use crate::verifier::verify;
 
-#[test]
-fn test_completeness() {
-    use ff::{Field, PrimeField};
-    use zcash_primitives::jubjub::{JubjubBls12, JubjubParams, PrimeOrder, FixedGenerators, fs, edwards,};
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::time::SystemTime;
+
+    use ff::Field;
+    use bellman::groth16::{prepare_verifying_key, Parameters};
+    use zcash_primitives::jubjub::{JubjubBls12, JubjubParams, FixedGenerators, fs, edwards};
     use pairing::bls12_381::{Bls12, Fr};
-    use rand_core::{RngCore, SeedableRng,};
+    use rand_core::SeedableRng;
     use rand_xorshift::XorShiftRng;
 
-    let rng = &mut XorShiftRng::from_seed([
-        0x58, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
-        0xe5,
-    ]);
+    use super::*;
 
-    let params = &JubjubBls12::new();
+    #[test]
+    fn test_completeness() {
+        let rng = &mut XorShiftRng::from_seed([
+            0x58, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
-    let f = match File::open("crs") {
-        Ok(f) => f,
-        Err(_) => {
-            let mut f = File::create("crs").unwrap();
-            let t = SystemTime::now();
-            let c = generator::generate_crs().expect("can't generate CRS");
-            println!("generation = {}", t.elapsed().unwrap().as_secs());
-            c.write(&f);
-            f //TODO
-        },
-    };
+        let params = &JubjubBls12::new();
 
-    let crs = Parameters::<Bls12>::read(f, false).expect("can't read CRS");
+        let crs = match File::open("crs") {
+            Ok(f) => Parameters::<Bls12>::read(f, false).expect("can't read CRS"),
+            Err(_) => {
+                let f = File::create("crs").unwrap();
+                let t = SystemTime::now();
+                let c = generator::generate_crs().expect("can't generate CRS");
+                println!("generation = {}", t.elapsed().unwrap().as_secs());
+                c.write(&f).unwrap();
+                c
+            },
+        };
 
-    // Jubjub generator point // TODO: prime or---
-    let base_point = params.generator(FixedGenerators::SpendingKeyGenerator);
+        // Jubjub generator point // TODO: prime or---
+        let base_point = params.generator(FixedGenerators::SpendingKeyGenerator);
 
-    // validator's secret key, an element of Jubjub scalar field
-    let sk = fs::Fs::random(rng);
+        // validator's secret key, an element of Jubjub scalar field
+        let sk = fs::Fs::random(rng);
 
-    // validator's public key, a point on Jubjub
-    let pk = base_point.mul(sk, params);
+        // validator's public key, a point on Jubjub
+        let pk = base_point.mul(sk, params);
 
-    // VRF base point
-    let vrf_base = edwards::Point::rand(rng, params).mul_by_cofactor(params);
+        // VRF base point
+        let vrf_base = edwards::Point::rand(rng, params).mul_by_cofactor(params);
 
-    let vrf_output = vrf_base.mul(sk, params);
+        let vrf_output = vrf_base.mul(sk, params);
 
-    let tree_depth = 10;
-    let auth_path = vec![Some((Fr::random(rng), rng.next_u32() % 2 != 0)); tree_depth];
+        let tree_depth = 10;
+        let auth_path = vec![(Fr::random(rng), PathDirection::random(rng)); tree_depth];
 
-    let mut apk_x = pk.to_xy().0;
+        let apkx = aggregated_pkx::<Bls12>(params, pk.to_xy().0, &auth_path);
 
-    for (i, val) in auth_path.clone().into_iter().enumerate() {
-        let (uncle, b) = val.unwrap();
+        let t = SystemTime::now();
+        let proof = prover::prove(params, &crs, sk, vrf_base.clone(), auth_path.clone());
+        println!("proving = {}", t.elapsed().unwrap().as_millis());
+        let proof = proof.unwrap();
 
-        let mut lhs = apk_x;
-        let mut rhs = uncle;
-
-        if b {
-            ::std::mem::swap(&mut lhs, &mut rhs);
-        }
-
-        let mut lhs: Vec<bool> = BitIterator::new(lhs.into_repr()).collect();
-        let mut rhs: Vec<bool> = BitIterator::new(rhs.into_repr()).collect();
-
-        lhs.reverse();
-        rhs.reverse();
-
-        apk_x = pedersen_hash::pedersen_hash::<Bls12, _>(
-            pedersen_hash::Personalization::MerkleTree(i),
-            lhs.into_iter()
-                .take(Fr::NUM_BITS as usize)
-                .chain(rhs.into_iter().take(Fr::NUM_BITS as usize)),
-            params,
-        )
-            .to_xy()
-            .0;
+        let t = SystemTime::now();
+        let pvk = prepare_verifying_key::<Bls12>(&crs.vk);
+        let valid = verifier::verify(&pvk, proof, vrf_base, vrf_output, apkx);
+        println!("verification = {}", t.elapsed().unwrap().as_millis());
+        assert_eq!(valid.unwrap(), true);
     }
-
-
-    let t = SystemTime::now();
-    let proof = prover::prove(params, &crs, sk, vrf_base.clone(), auth_path.clone());
-    println!("proving = {}", t.elapsed().unwrap().as_millis());
-    let proof = proof.unwrap();
-
-    let t = SystemTime::now();
-    let pvk = prepare_verifying_key::<Bls12>(&crs.vk);
-    let valid = verifier::verify(params, &pvk, proof, vrf_base, vrf_output, apk_x);
-    println!("verification = {}", t.elapsed().unwrap().as_millis());
-    assert_eq!(valid.unwrap(), true);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,8 @@ pub use crate::generator::generate_crs;
 pub use crate::prover::prove;
 pub use crate::verifier::{verify, verify_prepared};
 
-use zcash_primitives::jubjub::JubjubEngine;
+use ff::{Field, ScalarEngine};
+use zcash_primitives::jubjub::{JubjubEngine, FixedGenerators, JubjubParams, PrimeOrder, edwards};
 
 /// Configuration parameters for the system.
 pub struct Params<E: JubjubEngine> {
@@ -20,14 +21,54 @@ pub struct Params<E: JubjubEngine> {
     pub auth_depth: usize,
 }
 
+/// Private key.
+#[derive(Debug, Clone)]
+pub struct PrivateKey<E: JubjubEngine>(pub E::Fs);
+
+impl<E: JubjubEngine> PrivateKey<E> {
+    /// Random private key.
+    pub fn random<R: rand_core::RngCore>(rng: &mut R) -> Self {
+        Self(<E::Fs>::random(rng))
+    }
+
+    /// Into public key.
+    pub fn into_public(&self, params: &Params<E>) -> PublicKey<E> {
+        // Jubjub generator point. TODO: prime or ---
+        let base_point = params.engine.generator(FixedGenerators::SpendingKeyGenerator);
+        base_point.mul(self.0.clone(), &params.engine).to_xy().0
+    }
+}
+
+/// Public key.
+pub type PublicKey<E> = <E as ScalarEngine>::Fr;
+
+/// VRF input.
+#[derive(Debug, Clone)]
+pub struct VRFInput<E: JubjubEngine>(pub edwards::Point<E, PrimeOrder>);
+
+impl<E: JubjubEngine> VRFInput<E> {
+    /// Create a new random VRF input.
+    pub fn random<R: rand_core::RngCore>(rng: &mut R, params: &Params<E>) -> Self {
+        Self(edwards::Point::rand(rng, &params.engine).mul_by_cofactor(&params.engine))
+    }
+
+    /// Into VRF output.
+    pub fn into_output(&self, sk: &PrivateKey<E>, params: &Params<E>) -> VRFOutput<E> {
+        self.0.mul(sk.0.clone(), &params.engine)
+    }
+}
+
+
+/// VRF output.
+pub type VRFOutput<E> = edwards::Point<E, PrimeOrder>;
+
 #[cfg(test)]
 mod tests {
     use std::fs::File;
     use std::time::SystemTime;
 
-    use ff::Field;
     use bellman::groth16::Parameters;
-    use zcash_primitives::jubjub::{JubjubBls12, JubjubParams, FixedGenerators, fs, edwards};
+    use zcash_primitives::jubjub::JubjubBls12;
     use pairing::bls12_381::Bls12;
     use rand_core::SeedableRng;
     use rand_xorshift::XorShiftRng;
@@ -58,29 +99,22 @@ mod tests {
             },
         };
 
-        // Jubjub generator point // TODO: prime or---
-        let base_point = params.engine.generator(FixedGenerators::SpendingKeyGenerator);
+        let sk = PrivateKey::<Bls12>::random(rng);
+        let pk = sk.into_public(&params);
 
-        // validator's secret key, an element of Jubjub scalar field
-        let sk = fs::Fs::random(rng);
-
-        // validator's public key, a point on Jubjub
-        let pk = base_point.mul(sk, &params.engine);
-
-        // VRF base point
-        let vrf_base = edwards::Point::rand(rng, &params.engine).mul_by_cofactor(&params.engine);
-        let vrf_output = vrf_base.mul(sk, &params.engine);
+        let vrf_input = VRFInput::<Bls12>::random(rng, &params);
+        let vrf_output = vrf_input.into_output(&sk, &params);
 
         let auth_path = AuthPath::random(params.auth_depth, rng);
-        let auth_root = AuthRoot::from_proof(&auth_path, &pk.to_xy().0, &params);
+        let auth_root = AuthRoot::from_proof(&auth_path, &pk, &params);
 
         let t = SystemTime::now();
-        let proof = prover::prove::<Bls12>(&crs, sk, vrf_base.clone(), auth_path.clone(), &params);
+        let proof = prover::prove::<Bls12>(&crs, sk, vrf_input.clone(), auth_path.clone(), &params);
         println!("proving = {}", t.elapsed().unwrap().as_millis());
         let proof = proof.unwrap();
 
         let t = SystemTime::now();
-        let valid = verifier::verify(&crs, proof, vrf_base, vrf_output, auth_root);
+        let valid = verifier::verify(&crs, proof, vrf_input, vrf_output, auth_root);
         println!("verification = {}", t.elapsed().unwrap().as_millis());
         assert_eq!(valid.unwrap(), true);
     }

--- a/src/merkle.rs
+++ b/src/merkle.rs
@@ -1,51 +1,182 @@
-use ff::{PrimeField, BitIterator};
+use std::ops::{Deref, DerefMut};
+use ff::{PrimeField, BitIterator, Field};
 use pairing::bls12_381::Fr;
 use zcash_primitives::jubjub::JubjubEngine;
 use zcash_primitives::pedersen_hash;
+use crate::Params;
 
+/// A point in the authentication path.
+#[derive(Clone, Debug)]
+pub struct AuthPathPoint<E: JubjubEngine> {
+    /// The current selection. That is, the opposite of sibling.
+    pub current_selection: MerkleSelection,
+    /// Sibling value, if it exists.
+    pub sibling: Option<E::Fr>,
+}
+
+/// The authentication path of the merkle tree.
+#[derive(Clone, Debug)]
+pub struct AuthPath<E: JubjubEngine>(pub Vec<AuthPathPoint<E>>);
+
+impl<E: JubjubEngine> AuthPath<E> {
+    /// Create a random path.
+    pub fn random<R: rand_core::RngCore>(depth: usize, rng: &mut R) -> Self {
+        Self(vec![AuthPathPoint {
+            current_selection: MerkleSelection::random(rng),
+            sibling: Some(<E::Fr>::random(rng))
+        }; depth])
+    }
+
+    /// Create a path from a given plain list, of target specified as `list_index`.
+    /// Panic if `list_index` is out of bound.
+    pub fn from_list(list: &[E::Fr], list_index: usize, params: &Params<E>) -> Self {
+        let mut depth_to_bottom = 0;
+        let mut tracked_index = list_index;
+        let mut cur = list.iter().cloned().collect::<Vec<_>>();
+        let mut path = <AuthPath<E>>::default();
+
+        while cur.len() > 1 {
+            let mut next = Vec::new();
+
+            let left = cur.pop();
+            let right = cur.pop();
+
+            next.push(auth_hash::<E>(left.as_ref(), right.as_ref(), depth_to_bottom, params));
+
+            let (current_selection, sibling_index) = if tracked_index % 2 == 0 {
+                (MerkleSelection::Left, tracked_index + 1)
+            } else {
+                (MerkleSelection::Right, tracked_index - 1)
+            };
+            path.push(AuthPathPoint {
+                current_selection,
+                sibling: next.get(sibling_index).cloned()
+            });
+
+            cur = next;
+            depth_to_bottom += 1;
+            tracked_index /= 2;
+        }
+
+        path
+    }
+}
+
+impl<E: JubjubEngine> Default for AuthPath<E> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<E: JubjubEngine> Deref for AuthPath<E> {
+    type Target = Vec<AuthPathPoint<E>>;
+
+    fn deref(&self) -> &Vec<AuthPathPoint<E>> {
+        &self.0
+    }
+}
+
+impl<E: JubjubEngine> DerefMut for AuthPath<E> {
+    fn deref_mut(&mut self) -> &mut Vec<AuthPathPoint<E>> {
+        &mut self.0
+    }
+}
+
+/// The authentication root / merkle root of a given tree.
+pub struct AuthRoot<E: JubjubEngine>(pub E::Fr);
+
+impl<E: JubjubEngine> Deref for AuthRoot<E> {
+    type Target = E::Fr;
+
+    fn deref(&self) -> &E::Fr {
+        &self.0
+    }
+}
+
+impl<E: JubjubEngine> DerefMut for AuthRoot<E> {
+    fn deref_mut(&mut self) -> &mut E::Fr {
+        &mut self.0
+    }
+}
+
+impl<E: JubjubEngine> AuthRoot<E> {
+    /// Get the merkle root from proof.
+    pub fn from_proof(path: &AuthPath<E>, target: &E::Fr, params: &Params<E>) -> Self {
+        let mut cur = target.clone();
+
+        for (depth_to_bottom, point) in path.iter().enumerate() {
+            let (left, right) = match point.current_selection {
+                MerkleSelection::Right => (point.sibling.as_ref(), Some(&cur)),
+                MerkleSelection::Left => (Some(&cur), point.sibling.as_ref()),
+            };
+
+            cur = auth_hash::<E>(left, right, depth_to_bottom, params);
+        }
+
+        Self(cur)
+    }
+
+    /// Get the merkle root from a plain list. Panic if length of the list is zero.
+    pub fn from_list(list: &[E::Fr], params: &Params<E>) -> Self {
+        let mut depth_to_bottom = 0;
+        let mut cur = list.iter().cloned().collect::<Vec<_>>();
+
+        while cur.len() > 1 {
+            let mut next = Vec::new();
+
+            let left = cur.pop();
+            let right = cur.pop();
+
+            next.push(auth_hash::<E>(left.as_ref(), right.as_ref(), depth_to_bottom, params));
+
+            cur = next;
+            depth_to_bottom += 1;
+        }
+
+        Self(cur.pop().expect("initial list is not empty; qed"))
+    }
+}
+
+/// Hash function used to create the authentication merkle tree.
+pub fn auth_hash<E: JubjubEngine>(
+    left: Option<&E::Fr>,
+    right: Option<&E::Fr>,
+    depth_to_bottom: usize,
+    params: &Params<E>,
+) -> E::Fr {
+    let zero = <E::Fr>::zero();
+
+    let mut lhs = BitIterator::new(left.unwrap_or(&zero).into_repr()).collect::<Vec<bool>>();
+    let mut rhs = BitIterator::new(right.unwrap_or(&zero).into_repr()).collect::<Vec<bool>>();
+
+    lhs.reverse();
+    rhs.reverse();
+
+    pedersen_hash::pedersen_hash::<E, _>(
+        pedersen_hash::Personalization::MerkleTree(depth_to_bottom),
+        lhs.into_iter()
+            .take(Fr::NUM_BITS as usize)
+            .chain(rhs.into_iter().take(Fr::NUM_BITS as usize)),
+        &params.engine,
+    ).to_xy().0
+}
+
+/// Direction of the binary merkle path, either going left or right.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum PathDirection {
+pub enum MerkleSelection {
+    /// Move left to the sub-node.
     Left,
+    /// Move right to the sub-node.
     Right,
 }
 
-impl PathDirection {
+impl MerkleSelection {
+    /// Create a random path direction from a random source.
     pub fn random<R: rand_core::RngCore>(rng: &mut R) -> Self {
         if rng.next_u32() % 2 == 0 {
-            PathDirection::Left
+            MerkleSelection::Left
         } else {
-            PathDirection::Right
+            MerkleSelection::Right
         }
     }
-}
-
-pub fn aggregated_pkx<E: JubjubEngine>(
-    params: &E::Params,
-    pk_x: E::Fr,
-    path: &[(E::Fr, PathDirection)]
-) -> E::Fr {
-    let mut cur = pk_x.clone();
-
-    for (i, (uncle, direction)) in path.iter().enumerate() {
-        let (lhs, rhs) = match direction {
-            PathDirection::Left => (&cur, uncle),
-            PathDirection::Right => (uncle, &cur),
-        };
-
-        let mut lhs = BitIterator::new(lhs.into_repr()).collect::<Vec<bool>>();
-        let mut rhs = BitIterator::new(rhs.into_repr()).collect::<Vec<bool>>();
-
-        lhs.reverse();
-        rhs.reverse();
-
-        cur = pedersen_hash::pedersen_hash::<E, _>(
-            pedersen_hash::Personalization::MerkleTree(i),
-            lhs.into_iter()
-                .take(Fr::NUM_BITS as usize)
-                .chain(rhs.into_iter().take(Fr::NUM_BITS as usize)),
-            params,
-        ).to_xy().0;
-    }
-
-    cur
 }

--- a/src/merkle.rs
+++ b/src/merkle.rs
@@ -1,0 +1,51 @@
+use ff::{PrimeField, BitIterator};
+use pairing::bls12_381::Fr;
+use zcash_primitives::jubjub::JubjubEngine;
+use zcash_primitives::pedersen_hash;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum PathDirection {
+    Left,
+    Right,
+}
+
+impl PathDirection {
+    pub fn random<R: rand_core::RngCore>(rng: &mut R) -> Self {
+        if rng.next_u32() % 2 == 0 {
+            PathDirection::Left
+        } else {
+            PathDirection::Right
+        }
+    }
+}
+
+pub fn aggregated_pkx<E: JubjubEngine>(
+    params: &E::Params,
+    pk_x: E::Fr,
+    path: &[(E::Fr, PathDirection)]
+) -> E::Fr {
+    let mut cur = pk_x.clone();
+
+    for (i, (uncle, direction)) in path.iter().enumerate() {
+        let (lhs, rhs) = match direction {
+            PathDirection::Left => (&cur, uncle),
+            PathDirection::Right => (uncle, &cur),
+        };
+
+        let mut lhs = BitIterator::new(lhs.into_repr()).collect::<Vec<bool>>();
+        let mut rhs = BitIterator::new(rhs.into_repr()).collect::<Vec<bool>>();
+
+        lhs.reverse();
+        rhs.reverse();
+
+        cur = pedersen_hash::pedersen_hash::<E, _>(
+            pedersen_hash::Personalization::MerkleTree(i),
+            lhs.into_iter()
+                .take(Fr::NUM_BITS as usize)
+                .chain(rhs.into_iter().take(Fr::NUM_BITS as usize)),
+            params,
+        ).to_xy().0;
+    }
+
+    cur
+}

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -1,17 +1,16 @@
-use bellman::groth16::{create_random_proof, Parameters, Proof,};
+use bellman::groth16::{create_random_proof, Parameters, Proof};
 use pairing::bls12_381::{Bls12, Fr};
-use zcash_primitives::jubjub::{JubjubBls12, edwards, Unknown, fs, PrimeOrder};
-use super::circuit::Ring;
+use zcash_primitives::jubjub::{JubjubBls12, edwards, fs, PrimeOrder};
 use rand_core::OsRng;
+use crate::{Ring, PathDirection};
 
 pub fn prove(
     params: &JubjubBls12,
     proving_key: &Parameters<Bls12>,
     sk: fs::Fs,
     vrf_base: edwards::Point<Bls12, PrimeOrder>,
-    auth_path: Vec<Option<(Fr, bool)>>
+    auth_path: Vec<(Fr, PathDirection)>
 ) -> Result<Proof<Bls12>, ()> {
-//    let params = &JubjubBls12::new();
     let mut rng = OsRng;
     let instance = Ring {
         params,

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -1,22 +1,21 @@
 use bellman::groth16::{create_random_proof, Parameters, Proof};
-use pairing::bls12_381::{Bls12, Fr};
-use zcash_primitives::jubjub::{JubjubBls12, edwards, fs, PrimeOrder};
+use zcash_primitives::jubjub::{JubjubEngine, edwards, PrimeOrder};
 use rand_core::OsRng;
-use crate::{Ring, PathDirection};
+use crate::{Ring, Params, AuthPath};
 
-pub fn prove(
-    params: &JubjubBls12,
-    proving_key: &Parameters<Bls12>,
-    sk: fs::Fs,
-    vrf_base: edwards::Point<Bls12, PrimeOrder>,
-    auth_path: Vec<(Fr, PathDirection)>
-) -> Result<Proof<Bls12>, ()> {
+pub fn prove<E: JubjubEngine>(
+    proving_key: &Parameters<E>,
+    sk: E::Fs,
+    vrf_base: edwards::Point<E, PrimeOrder>,
+    auth_path: AuthPath<E>,
+    params: &Params<E>,
+) -> Result<Proof<E>, ()> {
     let mut rng = OsRng;
     let instance = Ring {
         params,
         sk: Some(sk),
         vrf_input: Some(vrf_base),
-        auth_path: auth_path.into_iter().map(|a| Some(a)).collect(),
+        auth_path: Some(auth_path),
     };
     let proof =
         create_random_proof(instance, proving_key, &mut rng).expect("proving should not fail");

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -16,7 +16,7 @@ pub fn prove(
         params,
         sk: Some(sk),
         vrf_input: Some(vrf_base),
-        auth_path: auth_path,
+        auth_path: auth_path.into_iter().map(|a| Some(a)).collect(),
     };
     let proof =
         create_random_proof(instance, proving_key, &mut rng).expect("proving should not fail");

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -1,12 +1,12 @@
 use bellman::groth16::{create_random_proof, Parameters, Proof};
-use zcash_primitives::jubjub::{JubjubEngine, edwards, PrimeOrder};
+use zcash_primitives::jubjub::JubjubEngine;
 use rand_core::OsRng;
-use crate::{Ring, Params, AuthPath};
+use crate::{Ring, Params, AuthPath, VRFInput, PrivateKey};
 
 pub fn prove<E: JubjubEngine>(
     proving_key: &Parameters<E>,
-    sk: E::Fs,
-    vrf_base: edwards::Point<E, PrimeOrder>,
+    sk: PrivateKey<E>,
+    vrf_input: VRFInput<E>,
     auth_path: AuthPath<E>,
     params: &Params<E>,
 ) -> Result<Proof<E>, ()> {
@@ -14,7 +14,7 @@ pub fn prove<E: JubjubEngine>(
     let instance = Ring {
         params,
         sk: Some(sk),
-        vrf_input: Some(vrf_base),
+        vrf_input: Some(vrf_input),
         auth_path: Some(auth_path),
     };
     let proof =

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -1,13 +1,11 @@
-use bellman::groth16::{verify_proof, PreparedVerifyingKey, Proof,};
-use pairing::bls12_381::Bls12;
-use zcash_primitives::jubjub::{edwards, PrimeOrder, JubjubBls12, Unknown, JubjubEngine};
+use bellman::groth16::{verify_proof, PreparedVerifyingKey, Proof};
+use zcash_primitives::jubjub::{edwards, PrimeOrder, JubjubEngine};
 use ff::Field;
 
 use bellman::SynthesisError;
 
 // TODO: lifetime?
 pub fn verify<E: JubjubEngine>(
-    params: &E::Params,
     // Prepared means that 1 pairing e(alpha, beta) has been precomputed.
     // Makes sense, as we verify multiple proofs for the same circuit
     verifying_key: &PreparedVerifyingKey<E>,

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -1,16 +1,16 @@
 use bellman::groth16::{verify_proof, prepare_verifying_key, PreparedVerifyingKey, Parameters, Proof};
-use zcash_primitives::jubjub::{edwards, PrimeOrder, JubjubEngine};
+use zcash_primitives::jubjub::JubjubEngine;
 use ff::Field;
 use bellman::SynthesisError;
-use crate::AuthRoot;
+use crate::{AuthRoot, VRFInput, VRFOutput};
 
 /// Verify a proof using the given CRS, VRF input and output, and
 /// authentication root.
 pub fn verify<E: JubjubEngine>(
     proving_key: &Parameters<E>,
     zkproof: Proof<E>,
-    vrf_input: edwards::Point<E, PrimeOrder>,
-    vrf_output: edwards::Point<E, PrimeOrder>,
+    vrf_input: VRFInput<E>,
+    vrf_output: VRFOutput<E>,
     auth_root: AuthRoot<E>,
 ) -> Result<bool, SynthesisError> {
     let pvk = prepare_verifying_key::<E>(&proving_key.vk);
@@ -26,9 +26,9 @@ pub fn verify_prepared<E: JubjubEngine>(
     // Public inputs to check the proof against
     // in the order they should be assigned to the public inputs:
     // 1. VRF input, a point on Jubjub
-    vrf_input: edwards::Point<E, PrimeOrder>,
+    vrf_input: VRFInput<E>,
     // 2. VRF output, a point on Jubjub
-    vrf_output: edwards::Point<E, PrimeOrder>,
+    vrf_output: VRFOutput<E>,
     // 3. x-coordinate of the aggreagte public key
     auth_root: AuthRoot<E>,
 ) -> Result<bool, SynthesisError> {
@@ -36,7 +36,7 @@ pub fn verify_prepared<E: JubjubEngine>(
     // Public inputs are elements of the main curve (BLS12-381) scalar field (that matches Jubjub base field, that's the thing)
     let mut public_input = [E::Fr::zero(); 5];
     {
-        let (x, y) = vrf_input.to_xy();
+        let (x, y) = vrf_input.0.to_xy();
         public_input[0] = x;
         public_input[1] = y;
     }

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -1,8 +1,8 @@
 use bellman::groth16::{verify_proof, PreparedVerifyingKey, Proof};
 use zcash_primitives::jubjub::{edwards, PrimeOrder, JubjubEngine};
 use ff::Field;
-
 use bellman::SynthesisError;
+use crate::AuthRoot;
 
 // TODO: lifetime?
 pub fn verify<E: JubjubEngine>(
@@ -17,7 +17,7 @@ pub fn verify<E: JubjubEngine>(
     // 2. VRF output, a point on Jubjub
     vrf_output: edwards::Point<E, PrimeOrder>,
     // 3. x-coordinate of the aggreagte public key
-    apk_x: E::Fr,
+    auth_root: AuthRoot<E>,
 ) -> Result<bool, SynthesisError> {
     // TODO: subgroup checks
     // Public inputs are elements of the main curve (BLS12-381) scalar field (that matches Jubjub base field, that's the thing)
@@ -32,7 +32,7 @@ pub fn verify<E: JubjubEngine>(
         public_input[2] = x;
         public_input[3] = y;
     }
-    public_input[4] = apk_x;
+    public_input[4] = auth_root.0;
     // Verify the proof
     verify_proof(verifying_key, &zkproof, &public_input[..])
 }

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -1,11 +1,24 @@
-use bellman::groth16::{verify_proof, PreparedVerifyingKey, Proof};
+use bellman::groth16::{verify_proof, prepare_verifying_key, PreparedVerifyingKey, Parameters, Proof};
 use zcash_primitives::jubjub::{edwards, PrimeOrder, JubjubEngine};
 use ff::Field;
 use bellman::SynthesisError;
 use crate::AuthRoot;
 
-// TODO: lifetime?
+/// Verify a proof using the given CRS, VRF input and output, and
+/// authentication root.
 pub fn verify<E: JubjubEngine>(
+    proving_key: &Parameters<E>,
+    zkproof: Proof<E>,
+    vrf_input: edwards::Point<E, PrimeOrder>,
+    vrf_output: edwards::Point<E, PrimeOrder>,
+    auth_root: AuthRoot<E>,
+) -> Result<bool, SynthesisError> {
+    let pvk = prepare_verifying_key::<E>(&proving_key.vk);
+    verify_prepared(&pvk, zkproof, vrf_input, vrf_output, auth_root)
+}
+
+// TODO: lifetime?
+pub fn verify_prepared<E: JubjubEngine>(
     // Prepared means that 1 pairing e(alpha, beta) has been precomputed.
     // Makes sense, as we verify multiple proofs for the same circuit
     verifying_key: &PreparedVerifyingKey<E>,


### PR DESCRIPTION
* Added functionality to generate proof of `auth_path` from a plain list.
* Added many convenience functions and structs representing `VRFInput`, `VRFOutput`, `PrivateKey` and `PublicKey`, making the crate easier to use.
* Fixed some warnings and did some other refactorings.