### PR TITLE
Expose method for ephemeral secret key generation

### DIFF
--- a/bandersnatch_vrfs/src/lib.rs
+++ b/bandersnatch_vrfs/src/lib.rs
@@ -103,7 +103,6 @@ impl SecretKey {
         SecretKey( dleq_vrf::SecretKey::from_seed( thin_vrf(), seed ))
     }
 
-
     pub fn to_public(&self) -> PublicKey { 
         PublicKey( self.0.to_public() )
     }

--- a/bandersnatch_vrfs/src/lib.rs
+++ b/bandersnatch_vrfs/src/lib.rs
@@ -88,15 +88,21 @@ pub fn pedersen_vrf() -> PedersenVrf {
 }
 
 
-#[cfg(feature = "getrandom")]
 #[derive(Clone)]  // Zeroize
 pub struct SecretKey(pub dleq_vrf::SecretKey<E>);
 
 impl SecretKey {
+    /// Generate an ephemeral `SecretKey` with system randomness.
+    #[cfg(feature = "getrandom")]
+    pub fn ephemeral() -> Self {
+        Self(dleq_vrf::SecretKey::ephemeral(thin_vrf()))
+    }
+
     /// Generate a `SecretKey` from a 32 byte seed.
     pub fn from_seed(seed: &[u8; 32]) -> Self {
         SecretKey( dleq_vrf::SecretKey::from_seed( thin_vrf(), seed ))
     }
+
 
     pub fn to_public(&self) -> PublicKey { 
         PublicKey( self.0.to_public() )


### PR DESCRIPTION
only the `ephemeral` key gen should be under the `getrandom` feature flag, the `SecretKey` itself not.

Otherwise the crate fails to compile when `getrandom` is not activated (i.e. `impl SecretKey` can't be defined)