### PR TITLE
Make secret parameter immutable for signing operations

### DIFF
--- a/bandersnatch_vrfs/src/lib.rs
+++ b/bandersnatch_vrfs/src/lib.rs
@@ -116,7 +116,7 @@ impl SecretKey {
     }
 
     pub fn sign_thin_vrf<const N: usize>(
-        &mut self,
+        &self,
         t: impl IntoTranscript,
         ios: &[VrfInOut]
     ) -> ThinVrfSignature<N>
@@ -128,13 +128,13 @@ impl SecretKey {
     }
 
     pub fn sign_ring_vrf<const N: usize>(
-        &mut self,
+        &self,
         t: impl IntoTranscript,
         ios: &[VrfInOut]
     ) -> RingVrfSignature<N>
     {
         assert_eq!(ios.len(), N);
-        let (signature,secret_blinding) = pedersen_vrf().sign_pedersen_vrf(t, ios, None, &mut self.0);
+        let (signature,secret_blinding) = pedersen_vrf().sign_pedersen_vrf(t, ios, None, &self.0);
         let preoutputs = vrf::collect_preoutputs_array(ios);
         let ring_proof = (); // uses secret_blinding
         RingVrfSignature { preoutputs, signature, ring_proof, }

--- a/dleq_vrf/src/keys.rs
+++ b/dleq_vrf/src/keys.rs
@@ -80,7 +80,7 @@ impl<F: PrimeField> SecretScalar<F> {
     }
 
     /// Multiply by a scalar.
-    pub fn mul_by_challenge(&mut self, rhs: &F) -> F {
+    pub fn mul_by_challenge(&self, rhs: &F) -> F {
         let mut lhs = self.clone();
         lhs *= rhs;
         lhs.0[0] + lhs.0[1]

--- a/dleq_vrf/src/pedersen.rs
+++ b/dleq_vrf/src/pedersen.rs
@@ -225,7 +225,7 @@ where K: AffineRepr, H: AffineRepr<ScalarField = K::ScalarField>,
         t: impl IntoTranscript,
         ios: &[VrfInOut<H>],
         secret_blinding: Option<SecretBlinding<K,B>>,
-        secret: &mut SecretKey<K>,
+        secret: &SecretKey<K>,
     ) -> (Signature<PedersenVrf<K,H,B>>, SecretBlinding<K,B>)
     {
         let flavor = self;
@@ -297,7 +297,7 @@ where K: AffineRepr, H: AffineRepr<ScalarField = K::ScalarField>,
         self,
         t: &mut Transcript,
         secret_blindings: &SecretBlinding<K,B>,
-        secret: &mut SecretKey<K>,
+        secret: &SecretKey<K>,
         compk: KeyCommitment<K>,
     ) -> (Signature<PedersenVrf<K,H,B>>,NonBatchableSignature<PedersenVrf<K,H,B>>) {
         let Witness { r, k } = self;

--- a/dleq_vrf/src/thin.rs
+++ b/dleq_vrf/src/thin.rs
@@ -79,7 +79,7 @@ impl<K: AffineRepr> SecretKey<K> {
     /// Sign thin VRF signature
     /// 
     /// If `ios = &[]` this reduces to a Schnorr signature.
-    pub fn sign_thin_vrf(&mut self, t: impl IntoTranscript, ios: &[VrfInOut<K>]) -> Signature<ThinVrf<K>>
+    pub fn sign_thin_vrf(&self, t: impl IntoTranscript, ios: &[VrfInOut<K>]) -> Signature<ThinVrf<K>>
     {
         let mut t = t.into_transcript();
         let t = t.borrow_mut();
@@ -95,7 +95,7 @@ impl<K: AffineRepr> Witness<ThinVrf<K>> {
     /// 
     /// Assumes we already hashed public key, `VrfInOut`s, etc.
     pub(crate) fn sign_final(
-        self, t: &mut Transcript, secret: &mut SecretKey<K>
+        self, t: &mut Transcript, secret: &SecretKey<K>
     ) -> Signature<ThinVrf<K>> {
         let Witness { r, k } = self;
         t.label(b"Thin R");


### PR DESCRIPTION
Apparently not required and prevents cloning on user code