### PR TITLE
Expose some required things

### DIFF
--- a/bandersnatch_vrfs/src/lib.rs
+++ b/bandersnatch_vrfs/src/lib.rs
@@ -12,8 +12,9 @@ use ark_ec::{
     AffineRepr, CurveGroup,
     hashing::{HashToCurveError, curve_maps, map_to_curve_hasher::MapToCurveBasedHasher}, // HashToCurve
 };
-use ark_serialize::{CanonicalSerialize,CanonicalDeserialize};  // SerializationError
 use ark_std::{ borrow::BorrowMut, Zero, vec::Vec, };   // io::{Read, Write}
+
+pub use ark_serialize::{CanonicalSerialize,CanonicalDeserialize};  // SerializationError
 
 pub use ark_ed_on_bls12_381_bandersnatch::{
     self as bandersnatch,
@@ -151,8 +152,8 @@ pub struct PublicKey(pub dleq_vrf::PublicKey<E>);
 
 #[derive(Debug,Clone,CanonicalSerialize,CanonicalDeserialize)]
 pub struct ThinVrfSignature<const N: usize> {
-    signature: dleq_vrf::Signature<ThinVrf>,
-    preoutputs: [VrfPreOut; N],
+    pub signature: dleq_vrf::Signature<ThinVrf>,
+    pub preoutputs: [VrfPreOut; N],
 }
 
 impl<const N: usize> ThinVrfSignature<N>


### PR DESCRIPTION
### ThinVrfSignature components

I currently require this for a hack I crufted up.

We need to have access to a `Vec` version of `ThinVrfSignature` (i.e. without the generic) and methods (i.e. sign_thin_vrf_vec).

If is ok for you I can easily prepare a PR to do that.

In my code I had to re-define the `VrfSignature` with something like:

```
struct VrfSignature {
    proof: VrfProof,
    preout: Box<[bandersnatch_vrfs::VrfPreOut]>,
}
```

### Serialization traits

I prefer to not directly include any other dependency. Thus would be nice to expose the serialization traits directly from here.

An alternative, e.g. if we want to give some defaults, we may provide `to_bytes` and `from_bytes` methods directly to the types I need to serialize.