### PR TITLE
Refactory and Working Tests

### DIFF
--- a/ark-transcript/src/lib.rs
+++ b/ark-transcript/src/lib.rs
@@ -418,13 +418,13 @@ pub struct Reader(sha3::Shake128Reader);
 impl Reader {
     /// Read bytes from the transcript into the buffer.
     pub fn read_bytes(&mut self, buf: &mut [u8]) {
-        self.0.read(buf);
+        XofReader::read(&mut self.0, buf);
     }
 
     /// Read bytes from the transcript. Always succeed fully.
     pub fn read_byte_array<const N: usize>(&mut self) -> [u8; N] {
         let mut buf = [0u8; N];
-        self.0.read(&mut buf);
+        self.read_bytes(&mut buf);
         buf
     }
 

--- a/bandersnatch_vrfs/Cargo.toml
+++ b/bandersnatch_vrfs/Cargo.toml
@@ -27,7 +27,7 @@ merlin = { version = "3.0", default-features = false }
 ark-ed-on-bls12-381-bandersnatch = { version = "0.4", default-features = false }
 ark-bls12-381 = { version = "0.4", default-features = false, features = [ "curve" ] } # implies scalar_field
 sha2 = { version = "0.10", default-features = false }
-
+rand_chacha = { version = "0.3.1", default-features = false }
 
 [dev-dependencies]
 
@@ -38,4 +38,3 @@ getrandom = ["dleq_vrf/getrandom"]
 # std = ["getrandom", "ring/std"]  #  ["ark-std/std", "ark-ff/std", "ark-ec/std", "ark-poly/std", "ark-serialize/std"]
 # parallel = ["std", "ring/parallel"]  #  ["std", "rayon", "ark-std/parallel", "ark-ff/parallel", "ark-ec/parallel", "ark-poly/parallel"]
 print-trace = ["ark-std/print-trace"]
-

--- a/bandersnatch_vrfs/src/lib.rs
+++ b/bandersnatch_vrfs/src/lib.rs
@@ -146,7 +146,6 @@ impl SecretKey {
 #[derive(Debug,Clone,CanonicalSerialize,CanonicalDeserialize)]
 pub struct PublicKey(pub dleq_vrf::PublicKey<E>);
 
-
 #[derive(Debug,Clone,CanonicalSerialize,CanonicalDeserialize)]
 pub struct ThinVrfSignature<const N: usize> {
     pub signature: dleq_vrf::Signature<ThinVrf>,
@@ -171,12 +170,13 @@ impl<const N: usize> ThinVrfSignature<N>
     }
 }
 
+pub type PedersenVrfSignature = dleq_vrf::Signature<PedersenVrf>;
 
 #[derive(CanonicalSerialize,CanonicalDeserialize)]
 pub struct RingVrfSignature<const N: usize> {
-    signature: dleq_vrf::Signature<PedersenVrf>,
-    preoutputs: [VrfPreOut; N],
-    ring_proof: RingProof,
+    pub signature: dleq_vrf::Signature<PedersenVrf>,
+    pub preoutputs: [VrfPreOut; N],
+    pub ring_proof: RingProof,
 }
 
 impl<const N: usize> RingVrfSignature<N>

--- a/bandersnatch_vrfs/src/lib.rs
+++ b/bandersnatch_vrfs/src/lib.rs
@@ -231,14 +231,13 @@ mod tests {
     fn ring_test_init(pk: PublicKey) -> (RingProver, RingVerifier) {
         use ark_std::UniformRand;
 
-        // TODO @jeff: WHAT EXACTILY IS THIS DOMAIN SIZE and what value should we use?
         let kzg = ring::KZG::testing_kzg_setup([0; 32], 2usize.pow(10));
         let keyset_size = kzg.max_keyset_size();
 
         // Gen a bunch of random public keys
         let mut rng = rand_core::OsRng;
         let mut pks: Vec<_> = (0..keyset_size).map(|_| E::rand(&mut rng)).collect();
-        // Just select one spot for the actual key we are using
+        // Just select one index for the actual key we are for signing
         let secret_key_idx = keyset_size / 2;
         pks[secret_key_idx] = pk.0.0.into();
      

--- a/bandersnatch_vrfs/src/lib.rs
+++ b/bandersnatch_vrfs/src/lib.rs
@@ -4,9 +4,11 @@
 #![deny(unsafe_code)]
 #![doc = include_str!("../README.md")]
 
+pub mod ring;
 
 use rand_core::{CryptoRng, RngCore};
 use zeroize::Zeroize;
+use crate::ring::{RingProver, RingProof, RingVerifier};
 
 use ark_ec::{
     AffineRepr, CurveGroup,
@@ -28,17 +30,12 @@ pub use dleq_vrf::{
     vrf::{self, IntoVrfInput},
 };
 
-use bandersnatch::{
-    EdwardsAffine as E,
-};
+// use bandersnatch::EdwardsAffine as E;
+use bandersnatch::SWAffine as E;
 
 pub type VrfInput = dleq_vrf::vrf::VrfInput<E>;
 pub type VrfPreOut = dleq_vrf::vrf::VrfPreOut<E>;
 pub type VrfInOut = dleq_vrf::vrf::VrfInOut<E>;
-
-#[cfg(test)]
-mod tests;
-
 
 pub struct Message<'a> {
     pub domain: &'a [u8],
@@ -85,8 +82,7 @@ pub fn thin_vrf() -> ThinVrf {
 type PedersenVrf = dleq_vrf::PedersenVrf<E>;
 
 /// Pedersen VRF configured by the G1 generator for public key certs.
-pub fn pedersen_vrf() -> PedersenVrf {
-    let blinding_base = unimplemented!();
+pub fn pedersen_vrf(blinding_base: E) -> PedersenVrf {
     dleq_vrf::PedersenVrf::new( E::generator(), [ blinding_base ] )
 }
 
@@ -134,13 +130,14 @@ impl SecretKey {
         &self,
         t: impl IntoTranscript,
         ios: &[VrfInOut],
-        // ring_prover: &RingProver
+        ring_prover: &RingProver
     ) -> RingVrfSignature<N>
     {
         assert_eq!(ios.len(), N);
-        let (signature,secret_blinding) = pedersen_vrf().sign_pedersen_vrf(t, ios, None, &self.0);
+        let blinding_base = ring_prover.piop_params().h;
+        let (signature,secret_blinding) = pedersen_vrf(blinding_base).sign_pedersen_vrf(t, ios, None, &self.0);
         let preoutputs = vrf::collect_preoutputs_array(ios);
-        let ring_proof = (); // ring_prove(ring_prover,secret_blinding);
+        let ring_proof = ring_prover.prove(secret_blinding.0[0]);
         RingVrfSignature { preoutputs, signature, ring_proof, }
     }
 }
@@ -175,11 +172,11 @@ impl<const N: usize> ThinVrfSignature<N>
 }
 
 
-#[derive(Debug,Clone,CanonicalSerialize,CanonicalDeserialize)]
+#[derive(CanonicalSerialize,CanonicalDeserialize)]
 pub struct RingVrfSignature<const N: usize> {
     signature: dleq_vrf::Signature<PedersenVrf>,
     preoutputs: [VrfPreOut; N],
-    ring_proof: (), // RingProof
+    ring_proof: RingProof,
 }
 
 impl<const N: usize> RingVrfSignature<N>
@@ -188,17 +185,89 @@ impl<const N: usize> RingVrfSignature<N>
         &self,
         t: impl IntoTranscript,
         inputs: II,
-        // ring_verifier: &RingVerifier,
+        ring_verifier: &RingVerifier,
     ) -> SignatureResult<[VrfInOut; N]>
     where
         I: IntoVrfInput<E>,
         II: IntoIterator<Item=I>,
     {
         let ios = vrf::attach_inputs_array(&self.preoutputs,inputs);
-        pedersen_vrf().verify_pedersen_vrf(t,ios.as_ref(),&self.signature) ?;
-        // ring::ring_verify(ring_verifier, &self.ring_proof) ?;
-        Ok(ios)
+        let blinding_base = ring_verifier.piop_params().h;
+        pedersen_vrf(blinding_base).verify_pedersen_vrf(t,ios.as_ref(),&self.signature) ?;
+
+        let key_commitment = self.signature.as_key_commitment();
+        match ring_verifier.verify_ring_proof(self.ring_proof.clone(), key_commitment.0.clone()) {
+            true => Ok(ios),
+            false => Err(SignatureError::Invalid),
+        }
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::iter;
 
+    #[test]
+    fn thin_sign_verify() {
+        let secret = SecretKey::from_seed(&[0; 32]);
+        let public = secret.to_public();
+
+        let input = Message {
+            domain: b"domain",
+            message: b"message",
+        }.into_vrf_input();
+        let io = secret.0.vrf_inout(input.clone());
+        let transcript = Transcript::new_labeled(b"label");
+
+        let signature: ThinVrfSignature<1> = secret.sign_thin_vrf(transcript.clone(), &[io.clone()]);
+
+        let result = signature.verify_thin_vrf(transcript, iter::once(input), &public);
+        
+        assert!(result.is_ok());
+        let io2 = result.unwrap();
+        assert_eq!(io2[0].preoutput, io.preoutput);
+    }
+
+    fn ring_test_init(pk: PublicKey) -> (RingProver, RingVerifier) {
+        use ark_std::UniformRand;
+
+        // TODO @jeff: WHAT EXACTILY IS THIS DOMAIN SIZE and what value should we use?
+        let kzg = ring::KZG::insecure_kzg_setup([0; 32], 2usize.pow(10));
+        let keyset_size = kzg.max_keyset_size();
+
+        // Gen a bunch of random public keys
+        let mut rng = rand_core::OsRng;
+        let mut pks: Vec<_> = (0..keyset_size).map(|_| E::rand(&mut rng)).collect();
+        // Just select one spot for the actual key we are using
+        let secret_key_idx = keyset_size / 2;
+        pks[secret_key_idx] = pk.0.0.into();
+     
+        let prover_key = kzg.prover_key(pks.clone());
+        let ring_prover = kzg.init_ring_prover(prover_key, secret_key_idx);
+
+        let verifier_key = kzg.verifier_key(pks);
+        let ring_verifier = kzg.init_ring_verifier(verifier_key);
+
+        (ring_prover, ring_verifier)
+    }
+
+    #[test]
+    fn ring_sign_verify() {
+        let secret = SecretKey::from_seed(&[0; 32]);
+
+        let (ring_prover, ring_verifier) = ring_test_init(secret.to_public());
+        
+        let input = Message {
+            domain: b"domain",
+            message: b"message",
+        }.into_vrf_input();
+        let io = secret.0.vrf_inout(input.clone());
+        let transcript = Transcript::new_labeled(b"label");
+        
+        let signature: RingVrfSignature<1> = secret.sign_ring_vrf(transcript.clone(), &[io], &ring_prover);
+        
+        let result = signature.verify_ring_vrf(transcript, iter::once(input), &ring_verifier);
+        assert!(result.is_ok());
+    }
+}

--- a/bandersnatch_vrfs/src/ring.rs
+++ b/bandersnatch_vrfs/src/ring.rs
@@ -45,7 +45,26 @@ impl KZG {
     pub fn insecure_kzg_setup(seed: [u8;32], domain_size: usize) -> Self {
         let piop_params = make_piop_params(seed, domain_size);
 
-        let mut rng = rand_core::OsRng;
+        // let mut rng = rand_core::OsRng;
+        // TODO: davxy this is for testing only
+        use rand_core::SeedableRng;
+        let mut rng = rand_chacha::ChaCha20Rng::from_seed(seed.clone());
+
+        let pcs_params = RealKZG::setup(3 * domain_size, &mut rng);
+        KZG {
+            seed,
+            piop_params,
+            pcs_params,
+        }
+    }
+
+    // TODO: davxy this is for testing only
+    pub fn testing_kzg_setup(seed: [u8;32], domain_size: usize) -> Self {
+        let piop_params = make_piop_params(seed, domain_size);
+
+        use rand_core::SeedableRng;
+        let mut rng = rand_chacha::ChaCha20Rng::from_seed(seed);
+
         let pcs_params = RealKZG::setup(3 * domain_size, &mut rng);
         KZG {
             seed,
@@ -105,7 +124,7 @@ impl CanonicalDeserialize for KZG {
         let pcs_params = PcsParams::deserialize_with_mode(&mut reader, compress, validate)?;
         // TODO: @jeff should we serialize the original `domain_size` to get it back here?
         // Or shoud we use a global constant value?
-        let domain_size = 0; // FIXME
+        let domain_size = 2usize.pow(10); // FIXME
         let piop_params = make_piop_params(seed, domain_size);
         Ok(KZG {
             seed,

--- a/bandersnatch_vrfs/src/ring.rs
+++ b/bandersnatch_vrfs/src/ring.rs
@@ -1,126 +1,123 @@
+extern crate alloc;
+use alloc::vec::Vec;
 
 use ark_serialize::{
     CanonicalSerialize, CanonicalDeserialize, Valid, Compress, Validate, SerializationError,
+    Write, Read,
 };
 
 use merlin::Transcript;
 
 use fflonk::pcs::PCS;
-use common::domain::Domain;
+use ring::Domain;
 
 use ark_ed_on_bls12_381_bandersnatch::{Fq, Fr, SWConfig, SWAffine};
 
-// type SWConfig = <SWAffine as AffineRepr>::Config;
+type RealKZG = fflonk::pcs::kzg::KZG<ark_bls12_381::Bls12_381>;
 
-type PiopParams = PiopParams<Fq, SWConfig>;
+type PcsParams = fflonk::pcs::kzg::urs::URS<ark_bls12_381::Bls12_381>;
 
-fn make_piop_params(seed: [u8;32], domain_size: usize) -> PiopParams {
+pub type PiopParams = ring::PiopParams<Fq, SWConfig>;
+pub type RingProof = ring::RingProof<Fq, RealKZG>;
+pub type RingProver = ring::ring_prover::RingProver<Fq, RealKZG, SWConfig>;
+pub type RingVerifier = ring::ring_verifier::RingVerifier<Fq, RealKZG, SWConfig>;
+
+pub type ProverKey = ring::ProverKey<Fq, RealKZG, SWAffine>;
+pub type VerifierKey = ring::VerifierKey<Fq, RealKZG>;
+
+fn make_piop_params(seed: [u8; 32], domain_size: usize) -> PiopParams {
     use rand_core::SeedableRng;
-    let domain = Domain::new(domain_size, true);
     let mut rng = rand_chacha::ChaCha20Rng::from_seed(seed.clone());
+    let domain = Domain::new(domain_size, true);
     PiopParams::setup(domain, &mut rng)
 }
 
-// TODO: Import powers of tau
-#[cft(features = "getrandom")]
-pub fn insecure_kzg_setup(seed: [u8;32], domain_size: usize) -> KZG {
-    KZG {
-        piop_params: make_piop_params(seed.clone(), domain_size),
-        seed,
-        kzg: KZG::setup(3 * domain_size, rand_core::OsRng), // pcs_params
-    }
-}
-
-type RealKZG = fflonk::pcs::kzg::KZG<ark_bls12_381::Bls12_381>;
-
-#[derive(Debug,Clone)]
-pub use KZG {
+#[derive(Clone)]
+pub struct KZG {
     seed: [u8; 32],
     piop_params: PiopParams,
-    kzg: RealKZG,
+    pcs_params: PcsParams,
+}
+
+impl KZG {
+    // TODO: Import powers of tau
+    #[cfg(feature = "getrandom")]
+    pub fn insecure_kzg_setup(seed: [u8;32], domain_size: usize) -> Self {
+        let piop_params = make_piop_params(seed, domain_size);
+
+        let mut rng = rand_core::OsRng;
+        let pcs_params = RealKZG::setup(3 * domain_size, &mut rng);
+        KZG {
+            seed,
+            piop_params,
+            pcs_params,
+        }
+    }
+
+    pub fn max_keyset_size(&self) -> usize {
+        self.piop_params.keyset_part_size
+    }
+
+    pub fn prover_key(&self, pks: Vec<SWAffine>) -> ProverKey {
+        ring::index(self.pcs_params.clone(), &self.piop_params, pks).0
+    }
+
+    pub fn verifier_key(&self, pks: Vec<SWAffine>) -> VerifierKey {
+        ring::index(self.pcs_params.clone(), &self.piop_params, pks).1
+    }
+
+    /// `k` is the prover secret index in [0..keyset_size).
+    pub fn init_ring_prover(&self, prover_key: ProverKey, k: usize) -> RingProver {
+        RingProver::init(prover_key, self.piop_params.clone(), k, Transcript::new(b"ring-vrf-test"))
+    }
+
+    pub fn init_ring_verifier(&self, verifier_key: VerifierKey) -> RingVerifier {
+        RingVerifier::init(verifier_key, self.piop_params.clone(), Transcript::new(b"ring-vrf-test"))
+    }
 }
 
 impl CanonicalSerialize for KZG {
     // Required methods
     fn serialize_with_mode<W: Write>(
         &self,
-        writer: W,
+        mut writer: W,
         compress: Compress
     ) -> Result<(), SerializationError> 
     {
-        writer.write(&*self.seed).map_err(|e| SerializationError::IoError(e)) ?;
-        self.kzg.serialize_with_mode(&mut *writer, compress) ?;
+        writer.write(&self.seed).map_err(|e| SerializationError::IoError(e))?;
+        self.pcs_params.serialize_with_mode(&mut writer, compress)
     }
 
     fn serialized_size(&self, compress: Compress) -> usize {
-        32 + RealKZG::serialized_size(compress)
+        32 + self.pcs_params.serialized_size(compress)
     }
 }
 
-impl CanonicalDeserialize {
+impl CanonicalDeserialize for KZG {
     fn deserialize_with_mode<R: Read>(
-        reader: R,
+        mut reader: R,
         compress: Compress,
         validate: Validate
     ) -> Result<Self, SerializationError>
     {
         let mut seed = [0u8; 32];
-        reader.read(&mut seed).map_err(|e| SerializationError::IoError(e)) ?;
-        let kzg = C::BaseField::deserialize_with_mode(&mut *reader, compress, validate) ?;
-        KZG {
-            piop_params: make_piop_params(seed.clone(), domain_size),
+        reader.read(&mut seed).map_err(|e| SerializationError::IoError(e))?;
+        let pcs_params = PcsParams::deserialize_with_mode(&mut reader, compress, validate)?;
+        // TODO: @jeff should we serialize the original `domain_size` to get it back here?
+        // Or shoud we use a global constant value?
+        let domain_size = 0; // FIXME
+        let piop_params = make_piop_params(seed, domain_size);
+        Ok(KZG {
             seed,
-            kzg: Arc::new(kzg),
-        }
+            piop_params,
+            pcs_params,
+        })
     }
 }
 
 impl Valid for KZG {
     fn check(&self) -> Result<(), SerializationError> {
-        self.kzg.check()
+        self.pcs_params.check()
     }
-}
-
-impl KZG {
-    pub fn max_keyset_size(&self) -> usize {
-        self.piop_params.keyset_part_size
-    }
-
-    pub fn prover_key(&self, pks: Vec<SWAffine>) -> ProverKey {
-        let kzg: RealKZG = self.kzg.clone();
-        ring::piop::index::<_, CS, _>(kzg, &self.piop_params, pks).0
-    }
-
-    pub fn verifier_key(&self, pks: Vec<SWAffine>) -> VerifierKey {
-        let kzg: RealKZG = self.kzg.clone();
-        ring::piop::index::<_, CS, _>(kzg, &self.piop_params, pks).1
-    }
-}
-
-pub type ProverKey = ring::piop::ProverKey<Fq, RealKZG, SWAffine>;
-
-pub fn init_ring_prover(prover_key: &ProverKey, k: usize) -> RingProver {
-    ring::ring_prover::RingProver::init(prover_key, piop_params.clone(), k, Transcript::new(b"ring-vrf-test"))
-}
-
-pub type RingProver = ring::ring_prover::RingProver<Fq, RealKZG, SWConfig>;
-
-pub fn ring_prove(ring_prover: &RingProver, secret: SecretBlinding<Fq,1>) -> RingProof {
-    ring_prover.prove(secret.0[0]);
-}
-
-pub type VerifierKey = ring::piop::VerifierKey<Fq, RealKZG>;
-
-impl KZG {
-    pub fn init_ring_verifier(&self, verifier_key: &VerifierKey) -> RingVerifier {
-        ring::ring_verifier::RingVerifier::init(verifier_key, self.piop_params.clone(), Transcript::new(b"ring-vrf-test"))
-    }
-}
-
-pub type RingVerifier = ring::ring_verifier::RingVerifier<Fq, RealKZG, SWConfig>;
-
-pub fn ring_verify(ring_verifier: &RingVerifier, ring_proof: &RingProof, apk: &KeyCommitment) -> Result<(),()> {
-    let res = ring_verifier.verify_ring_proof(proof, apk.0);
-    if res { Ok(()) } else { Err(()) }
 }
 

--- a/dleq_vrf/src/pedersen.rs
+++ b/dleq_vrf/src/pedersen.rs
@@ -63,7 +63,7 @@ where K: AffineRepr, H: AffineRepr<ScalarField = K::ScalarField>
 /// that reveals the difference ebtween two public keys.
 #[derive(Clone,CanonicalSerialize,CanonicalDeserialize)] // Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash
 pub struct SecretBlinding<C: AffineRepr,const B: usize>(
-    pub(crate) [<C as AffineRepr>::ScalarField; B]
+    pub [<C as AffineRepr>::ScalarField; B]
 );
 
 impl<C: AffineRepr,const B: usize> Zeroize for SecretBlinding<C,B> {


### PR DESCRIPTION
- use SW instead of ED form (to match ring-proof requirements)
- actively use ring-proof
- a couple of tests
- expose `RingVrfSignature` and `VrfSignature` components to allow usage in substrate (we are using Vec of `VrfPreOut`)
- `insecure_kzg_setup` takes a generic `Rng` parameter.
- Introduced `testing_kzg_setup` to be used within tests