### PR TITLE
Adopt vrf traits + scale

### DIFF
--- a/bandersnatch_vrfs/Cargo.toml
+++ b/bandersnatch_vrfs/Cargo.toml
@@ -19,8 +19,6 @@ ark-ff.workspace = true
 ark-ec.workspace = true
 ark-serialize.workspace = true
 
-ark-scale = { worspace = true, features = [ "ec" ] }
-
 fflonk = { git = "https://github.com/w3f/fflonk" }
 ring = { git = "https://github.com/w3f/ring-proof", rev="0e948f3" }
 merlin = { version = "3.0", default-features = false }

--- a/dleq_vrf/src/scale.rs
+++ b/dleq_vrf/src/scale.rs
@@ -4,7 +4,7 @@ use ark_serialize::{CanonicalSerialize};
 use ark_ec::AffineRepr;
 
 // #[macro_use]
-use ark_scale::{
+pub use ark_scale::{
     ArkScaleMaxEncodedLen,MaxEncodedLen,
     impl_decode_via_ark,
     impl_encode_via_ark,

--- a/dleq_vrf/src/tests.rs
+++ b/dleq_vrf/src/tests.rs
@@ -23,16 +23,15 @@ type SecretKey = crate::SecretKey<K>;
 pub(crate) fn pedersen_vrf_test_flavor() -> PedersenVrf {
     let mut t = Transcript::new_labeled(b"TestFlavor");
     let mut reader = t.challenge(b"Keying&Blinding");
-    PedersenVrf::new(
-        reader.read_uniform(),
-        [reader.read_uniform()],
-    )
+    crate::ThinVrf { keying_base: reader.read_uniform(), }
+    .pedersen_vrf([ reader.read_uniform() ])
 }
+
 
 #[test]
 fn master() {
     let flavor = pedersen_vrf_test_flavor();
-    let mut sk = SecretKey::ephemeral((*flavor).clone());
+    let mut sk = (*flavor).clone().ephemeral_secretkey();
 
     let mk_io = |n: u32| {
         let input = vrf::ark_hash_to_curve::<K,H2C>(b"VrfIO",&n.to_le_bytes()[..]).unwrap();

--- a/dleq_vrf/src/traits.rs
+++ b/dleq_vrf/src/traits.rs
@@ -336,9 +336,9 @@ impl<K: AffineRepr> SecretKey<K> {
         &self,
         t: impl IntoTranscript,
         ios: &[VrfInOut<K>; N]
-    ) -> Result<VrfSignature<crate::PublicKey<K>,N>,()>
+    ) -> VrfSignature<crate::PublicKey<K>,N>
     {
-        self.vrf_sign(t,ios)
+        self.vrf_sign(t,ios).unwrap() // "Infalible"
     }
 
     pub fn sign_thin_vrf_one<I,T,F>(&self, input: I, check: F)
@@ -355,8 +355,8 @@ impl<K: AffineRepr> SecretKey<K> {
         &self,
         t: impl IntoTranscript,
         ios: &[VrfInOut<K>]
-    ) -> Result<VrfSignatureVec<crate::PublicKey<K>>,()>
+    ) -> VrfSignatureVec<crate::PublicKey<K>>
     {
-        self.vrf_sign_vec(t,ios)
+        self.vrf_sign_vec(t,ios).unwrap() // "Infalible"
     }
 }

--- a/nugget_bls/src/lib.rs
+++ b/nugget_bls/src/lib.rs
@@ -64,12 +64,12 @@ type PedersenVrf<P> = dleq_vrf::PedersenVrf<<P as Pairing>::G1Affine,<P as Pairi
 
 /// Then VRF configured by the G1 generator for signatures.
 pub fn thin_vrf<P: Pairing>() -> ThinVrf<P> {
-    dleq_vrf::ThinVrf { keying_base: <P as Pairing>::G1Affine::generator(), }
+    dleq_vrf::ThinVrf::default()  // keying_base: <P as Pairing>::G1Affine::generator()
 }
 
 /// Pedersen VRF configured by the G1 generator for public key certs.
 pub fn pedersen_vrf<P: Pairing>() -> PedersenVrf<P> {
-    dleq_vrf::PedersenVrf::new( <P as Pairing>::G1Affine::generator(), [] )
+    thin_vrf::<P>().pedersen_vrf([])
 }
 
 /// VrfInput from the G2 generator for public key certs.
@@ -88,12 +88,12 @@ impl<P: Pairing> SecretKey<P> {
     
     /// Generate an "unbiased" `SecretKey` from a user supplied `XofReader`.
     pub fn from_xof(xof: impl transcript::digest::XofReader) -> Self {
-        SecretKey( dleq_vrf::SecretKey::from_xof( thin_vrf::<P>(), xof ))
+        SecretKey( dleq_vrf::SecretKey::from_xof( xof ))
     }
 
     /// Generate a `SecretKey` from a 32 byte seed.
     pub fn from_seed(seed: &[u8; 32]) -> Self {
-        SecretKey( dleq_vrf::SecretKey::from_seed( thin_vrf::<P>(), seed ))
+        SecretKey( dleq_vrf::SecretKey::from_seed( seed ))
     }
 
     /// Generate an ephemeral `SecretKey` with system randomness.


### PR DESCRIPTION
We should handle scale earlier so all this code can easily be used elsewhere, so this does so.

I'd wrote these traits which I hope handle the various interface concerns generically.  It's always messy & subtle doing trait based interfaces though, so I waffled & delayed using them.  We should make a choice though, so I tried them out here.  

Interface changes slightly, as you'll see by reading the tests.  In essence, the main subtlety is that now this crate defines very few types, and the traits are not defined here either, which risks the wrath of the orphan rules, but looks okay.   Any thoughts?
