### PR TITLE
Housekeeping

### DIFF
--- a/bandersnatch_vrfs/Cargo.toml
+++ b/bandersnatch_vrfs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bandersnatch_vrfs"
 description = "Ring VRFs and thin VRF on bandersnatch"
 authors = ["Jeff Burdges <jeff@web3.foundation>"]
-version = "0.0.1"
+version = "0.0.2"
 repository = "https://github.com/w3f/ring-vrf/tree/master/bandersnatch_vrfs"
 edition = "2021"
 license = "MIT/Apache-2.0"

--- a/bandersnatch_vrfs/src/lib.rs
+++ b/bandersnatch_vrfs/src/lib.rs
@@ -8,7 +8,7 @@ pub mod ring;
 
 use ark_ec::{
     AffineRepr, CurveGroup,
-    hashing::{HashToCurveError, curve_maps, map_to_curve_hasher::MapToCurveBasedHasher}, // HashToCurve
+    // hashing::{HashToCurveError, curve_maps, map_to_curve_hasher::MapToCurveBasedHasher}, // HashToCurve
 };
 use ark_std::{vec::Vec};   // io::{Read, Write}
 

--- a/dleq_vrf/Cargo.toml
+++ b/dleq_vrf/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dleq_vrf"
 description = "VRFs from Chaum-Pedersen DLEQ proofs, usable in Ring VRFs"
 authors = ["Sergey Vasilyev <swasilyev@gmail.com>", "Jeff Burdges <jeff@web3.foundation>", "Syed Hosseini <syed@riseup.net>"]
-version = "0.0.2"
+version = "0.0.3"
 repository = "https://github.com/w3f/ring-vrf/tree/master/dleq_vrf"
 edition = "2021"
 license = "MIT/Apache-2.0"

--- a/dleq_vrf/src/lib.rs
+++ b/dleq_vrf/src/lib.rs
@@ -39,8 +39,9 @@ pub mod scale;
 
 pub mod traits;
 pub use traits::{
-    EcVrfSecret,EcVrfSigner,EcVrfVerifier,
-    VrfSignature,VrfSignatureVec,
+    EcVrfSecret, EcVrfSigner, EcVrfVerifier,
+    VrfSignature,
+    //VrfSignatureVec,
 };
 
 #[cfg(test)]

--- a/dleq_vrf/src/lib.rs
+++ b/dleq_vrf/src/lib.rs
@@ -26,10 +26,10 @@ pub mod vrf;
 pub use vrf::{IntoVrfInput, VrfInput, VrfPreOut, VrfInOut};
 
 mod thin;
-pub use thin::{ThinVrf};
+pub use thin::ThinVrf;
 
 mod pedersen;
-pub use pedersen::{PedersenVrf};
+pub use pedersen::PedersenVrf;
 
 // #[cfg(feature = "getrandom")]
 // mod musig

--- a/dleq_vrf/src/scale.rs
+++ b/dleq_vrf/src/scale.rs
@@ -16,8 +16,8 @@ use crate::{
     VrfPreOut,PublicKey,
     pedersen::KeyCommitment,
     // ThinVrf,PedersenVrf,
-    flavor::{Flavor,InnerFlavor},
-    traits::{EcVrfVerifier,VrfSignature,VrfSignatureVec},
+    flavor::{Flavor, InnerFlavor},
+    traits::{VrfSignature, EcVrfProofBound},
 };
 
 
@@ -56,33 +56,31 @@ impl_point_wrapper!(VrfPreOut);
 impl_point_wrapper!(KeyCommitment);
 
 
-impl<V: EcVrfVerifier+?Sized> Decode for VrfSignatureVec<V> {
+// impl<V: EcVrfVerifier+?Sized> Decode for VrfSignatureVec<V> {
+//     impl_decode_via_ark!();
+// }
+
+// impl<V: EcVrfVerifier+?Sized> Encode for VrfSignatureVec<V> {
+//     impl_encode_via_ark!();
+// }
+
+// impl<V: EcVrfVerifier+?Sized> EncodeLike for VrfSignatureVec<V> {}
+
+
+impl<P: EcVrfProofBound, H: AffineRepr, const N: usize> Decode for VrfSignature<P, H, N> {
     impl_decode_via_ark!();
 }
 
-impl<V: EcVrfVerifier+?Sized> Encode for VrfSignatureVec<V> {
+impl<P: EcVrfProofBound, H: AffineRepr, const N: usize> Encode for VrfSignature<P, H, N> {
     impl_encode_via_ark!();
 }
 
-impl<V: EcVrfVerifier+?Sized> EncodeLike for VrfSignatureVec<V> {}
+impl<P: EcVrfProofBound, H: AffineRepr, const N: usize> EncodeLike for VrfSignature<P, H, N> {}
 
-
-impl<V: EcVrfVerifier+?Sized, const N: usize> Decode for VrfSignature<V,N> {
-    impl_decode_via_ark!();
-}
-
-impl<V: EcVrfVerifier+?Sized, const N: usize> Encode for VrfSignature<V,N> {
-    impl_encode_via_ark!();
-}
-
-impl<V: EcVrfVerifier+?Sized, const N: usize> EncodeLike for VrfSignature<V,N> {}
-
-impl<V: EcVrfVerifier+?Sized, const N: usize> MaxEncodedLen for VrfSignature<V,N> 
-where <V as EcVrfVerifier>::VrfProof: ArkScaleMaxEncodedLen
-{
+impl<P: EcVrfProofBound + ArkScaleMaxEncodedLen, H: AffineRepr, const N: usize> MaxEncodedLen for VrfSignature<P, H, N>  {
     fn max_encoded_len() -> usize {
-        let o = <<V as EcVrfVerifier>::H as AffineRepr>::zero().compressed_size();
-        N * o + <<V as EcVrfVerifier>::VrfProof as ArkScaleMaxEncodedLen>::max_encoded_len()
+        let o = H::zero().compressed_size();
+        N * o + <P as ArkScaleMaxEncodedLen>::max_encoded_len()
     }
 }
 

--- a/dleq_vrf/src/scale.rs
+++ b/dleq_vrf/src/scale.rs
@@ -17,7 +17,7 @@ use crate::{
     pedersen::KeyCommitment,
     // ThinVrf,PedersenVrf,
     flavor::{Flavor, InnerFlavor},
-    traits::{VrfSignature, EcVrfProofBound},
+    traits::{VrfSignature, VrfSignatureVec, EcVrfProofBound},
 };
 
 
@@ -56,17 +56,6 @@ impl_point_wrapper!(VrfPreOut);
 impl_point_wrapper!(KeyCommitment);
 
 
-// impl<V: EcVrfVerifier+?Sized> Decode for VrfSignatureVec<V> {
-//     impl_decode_via_ark!();
-// }
-
-// impl<V: EcVrfVerifier+?Sized> Encode for VrfSignatureVec<V> {
-//     impl_encode_via_ark!();
-// }
-
-// impl<V: EcVrfVerifier+?Sized> EncodeLike for VrfSignatureVec<V> {}
-
-
 impl<P: EcVrfProofBound, H: AffineRepr, const N: usize> Decode for VrfSignature<P, H, N> {
     impl_decode_via_ark!();
 }
@@ -76,6 +65,18 @@ impl<P: EcVrfProofBound, H: AffineRepr, const N: usize> Encode for VrfSignature<
 }
 
 impl<P: EcVrfProofBound, H: AffineRepr, const N: usize> EncodeLike for VrfSignature<P, H, N> {}
+
+
+impl<P: EcVrfProofBound, H: AffineRepr> Decode for VrfSignatureVec<P, H> {
+    impl_decode_via_ark!();
+}
+
+impl<P: EcVrfProofBound, H: AffineRepr> Encode for VrfSignatureVec<P, H> {
+    impl_encode_via_ark!();
+}
+
+impl<P: EcVrfProofBound, H: AffineRepr> EncodeLike for VrfSignatureVec<P, H> {}
+
 
 impl<P: EcVrfProofBound + ArkScaleMaxEncodedLen, H: AffineRepr, const N: usize> MaxEncodedLen for VrfSignature<P, H, N>  {
     fn max_encoded_len() -> usize {

--- a/dleq_vrf/src/tests.rs
+++ b/dleq_vrf/src/tests.rs
@@ -17,8 +17,6 @@ type H2C = ark_ec::hashing::map_to_curve_hasher::MapToCurveBasedHasher::<
 
 // type ThinVrf = crate::ThinVrf<K>;
 type PedersenVrf = crate::PedersenVrf<K>;
-type SecretKey = crate::SecretKey<K>;
-
 
 pub(crate) fn pedersen_vrf_test_flavor() -> PedersenVrf {
     let mut t = Transcript::new_labeled(b"TestFlavor");

--- a/dleq_vrf/src/thin.rs
+++ b/dleq_vrf/src/thin.rs
@@ -5,7 +5,7 @@
 
 //! ### Thin VRF routines
 
-use ark_std::borrow::{Borrow,BorrowMut};
+use ark_std::{borrow::{Borrow, BorrowMut}, vec::Vec};
 use ark_ec::{AffineRepr, CurveGroup};
 
 use crate::{
@@ -14,7 +14,7 @@ use crate::{
     keys::{PublicKey, SecretKey},
     error::{SignatureResult, SignatureError},
     vrf::{self, VrfInput, VrfInOut, IntoVrfInput},
-    traits::{EcVrfSigner, EcVrfVerifier, EcVrfInOut, EcVrfProofBound, VrfSignature},
+    traits::{EcVrfSigner, EcVrfVerifier, EcVrfInOut, EcVrfProofBound, VrfSignature, VrfSignatureVec},
 };
 
 
@@ -119,14 +119,14 @@ impl<K: AffineRepr> SecretKey<K> {
         self.vrf_sign_one(input,check)
     }
 
-    // pub fn sign_thin_vrf_vec(
-    //     &self,
-    //     t: impl IntoTranscript,
-    //     ios: &[VrfInOut<K>]
-    // ) -> VrfSignatureVec<crate::PublicKey<K>>
-    // {
-    //     self.vrf_sign_vec(t,ios).unwrap() // "Infalible"
-    // }
+    pub fn sign_thin_vrf_vec(
+        &self,
+        t: impl IntoTranscript,
+        ios: &[VrfInOut<K>]
+    ) -> VrfSignatureVec<ThinVrfProof<K>, K>
+    {
+        self.vrf_sign_vec(t,ios).unwrap() // "Infalible"
+    }
 }
 
 impl<K: AffineRepr> EcVrfSigner for SecretKey<K> {
@@ -189,15 +189,15 @@ impl<K: AffineRepr> PublicKey<K> {
         self.vrf_verify(t,inputs,signature)
     }
 
-    // pub fn verify_thin_vrf_vec(
-    //     &self,
-    //     t: impl IntoTranscript,
-    //     inputs: impl IntoIterator<Item = impl IntoVrfInput<K>>,
-    //     signature: &VrfSignatureVec<Self>,
-    // ) -> Result<Vec<VrfInOut<K>>,error::SignatureError>
-    // {
-    //     self.vrf_verify_vec(t,inputs,signature)
-    // }
+    pub fn verify_thin_vrf_vec(
+        &self,
+        t: impl IntoTranscript,
+        inputs: impl IntoIterator<Item = impl IntoVrfInput<K>>,
+        signature: &VrfSignatureVec<ThinVrfProof<K>, K>,
+    ) -> Result<Vec<VrfInOut<K>>, SignatureError>
+    {
+        self.vrf_verify_vec(t,inputs,signature)
+    }
 }
 
 impl<K: AffineRepr> EcVrfVerifier for (&ThinVrf<K>, &PublicKey<K>) {

--- a/dleq_vrf/src/traits.rs
+++ b/dleq_vrf/src/traits.rs
@@ -85,15 +85,15 @@ impl<P: EcVrfProofBound, H: AffineRepr, const N: usize> VrfSignature<P, H, N> {
         core::array::from_fn(cb)
     }
 
-    // pub fn vrf_verify<V: EcVrfVerifier>( 
-    //     &self,
-    //     t: impl IntoTranscript,
-    //     inputs: impl IntoIterator<Item = impl IntoVrfInput<H>>,
-    //     public: &impl EcVrfVerifier,
-    // ) -> Result<[VrfInOut<H>; N], V::Error>
-    // {
-    //     public.vrf_verify(t,inputs,self)
-    // }
+    pub fn vrf_verify<V: EcVrfVerifier<VrfProof = P, H = H>>( 
+        &self,
+        t: impl IntoTranscript,
+        inputs: impl IntoIterator<Item = impl IntoVrfInput<H>>,
+        verifier: &V
+    ) -> Result<[VrfInOut<H>; N], V::Error>
+    {
+        verifier.vrf_verify(t,inputs,self)
+    }
 }
 
 // #[derive(CanonicalSerialize,CanonicalDeserialize)]
@@ -183,7 +183,7 @@ pub trait EcVrfSecret<H: AffineRepr> {
 /// We delegate the `SecretKey::{vrf_preout, vrf_inout}` in the `vrf`
 /// module to these ones, which asures agreement.
 impl<H,K> EcVrfSecret<H> for SecretKey<K>
-where K: AffineRepr, H: AffineRepr<ScalarField = K::ScalarField>,
+    where K: AffineRepr, H: AffineRepr<ScalarField = K::ScalarField>,
 {
     fn vrf_preout(&self, input: &vrf::VrfInput<H>) -> VrfPreOut<H> {
         VrfPreOut( (&self.key * &input.0).into_affine() )


### PR DESCRIPTION
Closes https://github.com/w3f/ring-vrf/issues/59

- Define `VrfSignature` to be generic over an `EcProof` and group element `H` (instead over the `EcVrfVerifier`.
  This allows to don't propagate the lifetime of the implementations of `EcVrfVerifier` to the Signature.
   
- Some generic cleanup. E.g. the implementations for thin vrf were moved from `traits.rs` to `thin.rs`

This PR is mostly required to painlessly upgrade the Substrate dependency
(already tested in substrate)
