### PR TITLE
Borrow RingVerifier

### DIFF
--- a/bandersnatch_vrfs/src/lib.rs
+++ b/bandersnatch_vrfs/src/lib.rs
@@ -147,11 +147,11 @@ impl scale::ArkScaleMaxEncodedLen for RingVrfProof {
 }
 
 // TODO: Sergey, should this be #[derive(Debug,Clone)] ?
-pub struct RingVerifier(pub ring::RingVerifier);
+pub struct RingVerifier<'a>(pub &'a ring::RingVerifier);
 
 pub type RingVrfSignature<const N: usize> = dleq_vrf::VrfSignature<RingVrfProof,N>;
 
-impl EcVrfVerifier for RingVerifier {
+impl EcVrfVerifier for RingVerifier<'_> {
     type Proof = RingVrfProof;
     type Error = SignatureError;
 
@@ -173,7 +173,7 @@ impl EcVrfVerifier for RingVerifier {
     }
 }
 
-impl RingVerifier {
+impl RingVerifier<'_> {
     pub fn verify_ring_vrf<const N: usize>(
         &self,
         t: impl IntoTranscript,
@@ -308,7 +308,7 @@ mod tests {
         
         // TODO: serialize signature
 
-        let result = RingVerifier(ring_verifier)
+        let result = RingVerifier(&ring_verifier)
         .verify_ring_vrf(transcript, iter::once(input), &signature);
         assert!(result.is_ok());
     }

--- a/bandersnatch_vrfs/src/lib.rs
+++ b/bandersnatch_vrfs/src/lib.rs
@@ -222,41 +222,6 @@ impl<'a> RingProver<'a> {
 }
 
 
-
-/* 
-#[derive(CanonicalSerialize,CanonicalDeserialize)]
-pub struct RingVrfSignature<const N: usize> {
-    pub signature: dleq_vrf::Batchable<PedersenVrf>,
-    pub preoutputs: [VrfPreOut; N],
-    pub ring_proof: RingProof,
-}
-
-impl<const N: usize> RingVrfSignature<N>
-{
-    pub fn verify_ring_vrf<I,II>(
-        &self,
-        t: impl IntoTranscript,
-        inputs: II,
-        ring_verifier: &RingVerifier,
-    ) -> SignatureResult<[VrfInOut; N]>
-    where
-        I: IntoVrfInput<E>,
-        II: IntoIterator<Item=I>,
-    {
-        let ios = vrf::attach_inputs_array(&self.preoutputs,inputs);
-        let blinding_base = ring_verifier.piop_params().h;
-        pedersen_vrf(blinding_base).verify_pedersen_vrf(t,ios.as_ref(),&self.signature) ?;
-
-        let key_commitment = self.signature.as_key_commitment();
-        match ring_verifier.verify_ring_proof(self.ring_proof.clone(), key_commitment.0.clone()) {
-            true => Ok(ios),
-            false => Err(SignatureError::Invalid),
-        }
-    }
-}
-*/
-
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/dleq_vrf/src/lib.rs
+++ b/dleq_vrf/src/lib.rs
@@ -26,7 +26,7 @@ pub mod vrf;
 pub use vrf::{IntoVrfInput, VrfInput, VrfPreOut, VrfInOut};
 
 mod thin;
-pub use thin::{ThinVrf};
+pub use thin::{ThinVrf,ThinVrfProof};
 
 mod pedersen;
 pub use pedersen::{PedersenVrf};
@@ -39,7 +39,7 @@ pub mod scale;
 
 pub mod traits;
 pub use traits::{
-    EcVrfSecret,EcVrfSigner,EcVrfVerifier,
+    EcVrfSecret,EcVrfProof,EcVrfVerifier,EcVrfSigner,
     VrfSignature,VrfSignatureVec,
 };
 

--- a/dleq_vrf/src/scale.rs
+++ b/dleq_vrf/src/scale.rs
@@ -17,7 +17,7 @@ use crate::{
     pedersen::KeyCommitment,
     // ThinVrf,PedersenVrf,
     flavor::{Flavor,InnerFlavor},
-    traits::{EcVrfVerifier,VrfSignature,VrfSignatureVec},
+    traits::{EcVrfProof,VrfSignature,VrfSignatureVec},
 };
 
 
@@ -56,33 +56,31 @@ impl_point_wrapper!(VrfPreOut);
 impl_point_wrapper!(KeyCommitment);
 
 
-impl<V: EcVrfVerifier+?Sized> Decode for VrfSignatureVec<V> {
+impl<P: EcVrfProof> Decode for VrfSignatureVec<P> {
     impl_decode_via_ark!();
 }
 
-impl<V: EcVrfVerifier+?Sized> Encode for VrfSignatureVec<V> {
+impl<P: EcVrfProof> Encode for VrfSignatureVec<P> {
     impl_encode_via_ark!();
 }
 
-impl<V: EcVrfVerifier+?Sized> EncodeLike for VrfSignatureVec<V> {}
+impl<P: EcVrfProof> EncodeLike for VrfSignatureVec<P> {}
 
 
-impl<V: EcVrfVerifier+?Sized, const N: usize> Decode for VrfSignature<V,N> {
+impl<P: EcVrfProof, const N: usize> Decode for VrfSignature<P,N> {
     impl_decode_via_ark!();
 }
 
-impl<V: EcVrfVerifier+?Sized, const N: usize> Encode for VrfSignature<V,N> {
+impl<P: EcVrfProof, const N: usize> Encode for VrfSignature<P,N> {
     impl_encode_via_ark!();
 }
 
-impl<V: EcVrfVerifier+?Sized, const N: usize> EncodeLike for VrfSignature<V,N> {}
+impl<P: EcVrfProof, const N: usize> EncodeLike for VrfSignature<P,N> {}
 
-impl<V: EcVrfVerifier+?Sized, const N: usize> MaxEncodedLen for VrfSignature<V,N> 
-where <V as EcVrfVerifier>::VrfProof: ArkScaleMaxEncodedLen
-{
+impl<P: EcVrfProof+ArkScaleMaxEncodedLen, const N: usize> MaxEncodedLen for VrfSignature<P,N> {
     fn max_encoded_len() -> usize {
-        let o = <<V as EcVrfVerifier>::H as AffineRepr>::zero().compressed_size();
-        N * o + <<V as EcVrfVerifier>::VrfProof as ArkScaleMaxEncodedLen>::max_encoded_len()
+        let o = <<P as EcVrfProof>::H as AffineRepr>::zero().compressed_size();
+        N * o + <P as ArkScaleMaxEncodedLen>::max_encoded_len()
     }
 }
 

--- a/dleq_vrf/src/thin.rs
+++ b/dleq_vrf/src/thin.rs
@@ -161,7 +161,7 @@ impl<K: AffineRepr> ThinVrf<K> {
         // A priori, one expects thin_vrf_merge's msm could be merged
         // into the multiplication by c below, except thin_vrf_merge
         // only needs 128 bit scalar multiplications, so doing this
-        // should only boosts performance when ios.len() = 2.
+        // should harm performance, even when ios.len() = 1.
         let io = self.thin_vrf_merge(t, public, ios);
 
         // verify_final

--- a/dleq_vrf/src/thin.rs
+++ b/dleq_vrf/src/thin.rs
@@ -5,7 +5,7 @@
 
 //! ### Thin VRF routines
 
-use ark_std::borrow::{Borrow,BorrowMut};
+use ark_std::{borrow::{Borrow,BorrowMut}, vec::Vec};
 use ark_ec::{AffineRepr, CurveGroup};
 
 use crate::{
@@ -13,7 +13,8 @@ use crate::{
     flavor::{Flavor, InnerFlavor, Witness, Batchable},
     keys::{PublicKey, SecretKey},
     error::{SignatureResult, SignatureError},
-    vrf::{self, VrfInput, VrfInOut},
+    vrf::{self, IntoVrfInput, VrfInput, VrfInOut},
+    EcVrfVerifier,EcVrfSigner,
 };
 
 
@@ -84,7 +85,7 @@ impl<K: AffineRepr> SecretKey<K> {
     /// Sign thin VRF signature
     /// 
     /// If `ios = &[]` this reduces to a Schnorr signature.
-    pub fn sign_thin_vrf_detached(&self, t: impl IntoTranscript, ios: &[VrfInOut<K>]) -> Batchable<ThinVrf<K>>
+    pub fn sign_thin_vrf_detached(&self, t: impl IntoTranscript, ios: &[VrfInOut<K>]) -> ThinVrfProof<K>
     {
         let mut t = t.into_transcript();
         let t = t.borrow_mut();
@@ -183,3 +184,106 @@ impl<K: AffineRepr> ThinVrf<K> {
     }
 }
 
+
+// Implement traits interface //
+
+/// Thin VRF proof component
+pub type ThinVrfProof<K> = Batchable<ThinVrf<K>>;
+
+impl<K: AffineRepr> crate::EcVrfProof for Batchable<ThinVrf<K>> {
+    type H = K;
+}
+
+impl<K: AffineRepr> EcVrfVerifier for (&ThinVrf<K>,&PublicKey<K>) {
+    type Proof = ThinVrfProof<K>;
+    type Error = SignatureError;
+    fn vrf_verify_detached<'a>(
+        &self,
+        t: impl IntoTranscript,
+        ios: &'a [VrfInOut<K>],
+        signature: &Self::Proof,
+    ) -> Result<&'a [VrfInOut<K>],SignatureError>
+    {
+        self.0.verify_thin_vrf(t,ios,self.1,signature)
+    }
+}
+
+impl<K: AffineRepr> EcVrfVerifier for PublicKey<K> {
+    type Proof = ThinVrfProof<K>;
+    type Error = SignatureError;
+    fn vrf_verify_detached<'a>(
+        &self,
+        t: impl IntoTranscript,
+        ios: &'a [VrfInOut<K>],
+        signature: &Self::Proof,
+    ) -> Result<&'a [VrfInOut<K>],SignatureError>
+    {
+        crate::ThinVrf::default().verify_thin_vrf(t,ios,self,signature)
+    }
+}
+
+impl<K: AffineRepr> PublicKey<K> {
+    pub fn verify_thin_vrf<const N: usize>(
+        &self,
+        t: impl IntoTranscript,
+        inputs: impl IntoIterator<Item = impl IntoVrfInput<K>>,
+        signature: &crate::VrfSignature<ThinVrfProof<K>,N>,
+    ) -> Result<[VrfInOut<K>; N],SignatureError>
+    {
+        self.vrf_verify(t,inputs,signature)
+    }
+
+    pub fn verify_thin_vrf_vec(
+        &self,
+        t: impl IntoTranscript,
+        inputs: impl IntoIterator<Item = impl IntoVrfInput<K>>,
+        signature: &crate::VrfSignatureVec<ThinVrfProof<K>>,
+    ) -> Result<Vec<VrfInOut<K>>,SignatureError>
+    {
+        self.vrf_verify_vec(t,inputs,signature)
+    }
+}
+
+impl<K: AffineRepr> EcVrfSigner for SecretKey<K> {
+    type Proof = ThinVrfProof<K>;
+    type Error = ();
+    type Secret = Self;
+    fn vrf_sign_detached(
+        &self,
+        t: impl IntoTranscript,
+        ios: &[VrfInOut<K>]
+    ) -> Result<Self::Proof,()>
+    {
+        Ok(self.sign_thin_vrf_detached(t,ios))
+    }
+}
+
+impl<K: AffineRepr> SecretKey<K> {
+    pub fn sign_thin_vrf<const N: usize>(
+        &self,
+        t: impl IntoTranscript,
+        ios: &[VrfInOut<K>; N]
+    ) -> crate::VrfSignature<ThinVrfProof<K>,N>
+    {
+        self.vrf_sign(t,ios).unwrap() // "Infalible"
+    }
+
+    pub fn sign_thin_vrf_one<I,T,F>(&self, input: I, check: F)
+     -> Result<crate::VrfSignature<ThinVrfProof<K>,1>,()>
+    where
+        I: IntoVrfInput<K>,
+        T: IntoTranscript,
+        F: FnMut(&VrfInOut<K>) -> Result<T,()>,
+    {
+        self.vrf_sign_one(input,check)
+    }
+
+    pub fn sign_thin_vrf_vec(
+        &self,
+        t: impl IntoTranscript,
+        ios: &[VrfInOut<K>]
+    ) -> crate::VrfSignatureVec<ThinVrfProof<K>>
+    {
+        self.vrf_sign_vec(t,ios).unwrap() // "Infalible"
+    }
+}

--- a/dleq_vrf/src/traits.rs
+++ b/dleq_vrf/src/traits.rs
@@ -72,8 +72,131 @@ pub trait EcVrfSecret<H: AffineRepr> {
 impl<H,K> EcVrfSecret<H> for SecretKey<K>
 where K: AffineRepr, H: AffineRepr<ScalarField = K::ScalarField>,
 {
-    fn vrf_preout(&self, input: &vrf::VrfInput<H>) -> VrfPreOut<H> {
+    fn vrf_preout(&self, input: &VrfInput<H>) -> VrfPreOut<H> {
         VrfPreOut( (&self.key * &input.0).into_affine() )
+    }
+}
+
+
+
+/// Elliptic curve VRF proof which defines signature types
+pub trait EcVrfProof:
+    fmt::Debug+Clone+Eq+PartialEq+CanonicalSerialize+CanonicalDeserialize + 'static
+{
+    /// Target group for hash-to-curve
+    type H: AffineRepr;
+}
+
+pub type EC<P> = <P as EcVrfProof>::H;
+pub type PreOut<P> = VrfPreOut<EC<P>>;
+pub type IO<P> = VrfInOut<EC<P>>;
+
+
+/// VRF signature with variable number of input-output pairs
+#[derive(CanonicalSerialize,CanonicalDeserialize)]
+pub struct VrfSignature<P: EcVrfProof, const N: usize> {
+    pub proof: P,
+    pub preouts: [PreOut<P>; N],
+}
+
+impl<P: EcVrfProof, const N: usize> Clone for VrfSignature<P,N> {
+    fn clone(&self) -> Self {
+        VrfSignature {
+            proof: self.proof.clone(),
+            preouts: self.preouts.clone(),
+        }
+    }
+}
+
+impl<P: EcVrfProof, const N: usize> fmt::Debug for VrfSignature<P,N> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "VrfSignature {{ proof: {:?}, preouts: {:?} }}", &self.proof, &self.preouts)
+	}
+}
+
+impl<P: EcVrfProof, const N: usize> Eq for VrfSignature<P,N> {}
+
+impl<P: EcVrfProof, const N: usize> PartialEq for VrfSignature<P,N> {
+    fn eq(&self, other: &Self) -> bool {
+        self.proof == other.proof && self.preouts == other.preouts
+    }
+}
+
+impl<P: EcVrfProof, const N: usize> VrfSignature<P,N> {
+    pub fn attach_inputs(
+        &self,
+        inputs: impl IntoIterator<Item = impl IntoVrfInput<P::H>>
+    ) -> [IO<P>; N]
+    {
+        let mut inputs = inputs.into_iter();
+        let mut preouts = self.preouts.iter().cloned();
+        let cb = |_| preouts.next().unwrap().attach_input(inputs.next().unwrap());
+        core::array::from_fn(cb)
+    }
+
+    pub fn vrf_verify<V>( 
+        &self,
+        t: impl IntoTranscript,
+        inputs: impl IntoIterator<Item = impl IntoVrfInput<P::H>>,
+        public: &V,
+    ) -> Result<[IO<P>; N],V::Error>
+    where V: EcVrfVerifier<Proof=P>
+    {
+        public.vrf_verify(t,inputs,self)
+    }
+}
+
+
+/// VRF signature with variable number of input-output pairs
+#[derive(CanonicalSerialize,CanonicalDeserialize)]
+pub struct VrfSignatureVec<P: EcVrfProof> {
+    pub proof: P,
+    pub preouts: Vec<PreOut<P>>,
+}
+
+impl<P: EcVrfProof> Clone for VrfSignatureVec<P> {
+    fn clone(&self) -> Self {
+        VrfSignatureVec {
+            proof: self.proof.clone(),
+            preouts: self.preouts.clone(),
+        }
+    }
+}
+
+impl<P: EcVrfProof> fmt::Debug for VrfSignatureVec<P> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "VrfSignature {{ proof: {:?}, preouts: {:?} }}", &self.proof, &self.preouts)
+	}
+}
+
+impl<P: EcVrfProof> Eq for VrfSignatureVec<P> {}
+
+impl<P: EcVrfProof> PartialEq for VrfSignatureVec<P> {
+    fn eq(&self, other: &Self) -> bool {
+        self.proof == other.proof && self.preouts == other.preouts
+    }
+}
+
+impl<P: EcVrfProof> VrfSignatureVec<P> {
+    pub fn attach_inputs(
+        &self,
+        inputs: impl IntoIterator<Item = impl IntoVrfInput<P::H>>
+    ) -> Vec<IO<P>>
+    {
+        self.preouts.iter().zip(inputs)
+        .map(|(preout,input)| preout.attach_input(input))
+        .collect()
+    }
+
+    pub fn vrf_verify<V>(
+        &self,
+        t: impl IntoTranscript,
+        inputs: impl IntoIterator<Item = impl IntoVrfInput<P::H>>,
+        public: &V,
+    ) -> Result<Vec<IO<P>>,V::Error>
+    where V: EcVrfVerifier<Proof=P>
+    {
+        public.vrf_verify_vec(t,inputs,self)
     }
 }
 
@@ -83,10 +206,8 @@ where K: AffineRepr, H: AffineRepr<ScalarField = K::ScalarField>,
 /// Inherent methods and other traits being used here:
 /// `IntoTranscript`, `vrf::{IntoVrfInput, VrfPreOut::attach_input, VrfInOut}`
 pub trait EcVrfVerifier {
-    /// Target group for hash-to-curve
-    type H: AffineRepr;
     /// Detached signature aka proof type created by the VRF
-    type VrfProof: fmt::Debug+Clone+Eq+PartialEq+CanonicalSerialize+CanonicalDeserialize;
+    type Proof: EcVrfProof;
 
     /// Verification failures
     type Error: From<error::SignatureError>; // = error::SignatureError;
@@ -94,18 +215,18 @@ pub trait EcVrfVerifier {
     fn vrf_verify_detached<'a>(
         &self,
         t: impl IntoTranscript,
-        ios: &'a [EcVrfInOut<Self>],        
-        signature: &EcVrfProof<Self>,
-    ) -> Result<&'a [EcVrfInOut<Self>],Self::Error>;
+        ios: &'a [IO<Self::Proof>],        
+        signature: &Self::Proof,
+    ) -> Result<&'a [IO<Self::Proof>],Self::Error>;
 
     fn vrf_verify<const N: usize>(
         &self,
         t: impl IntoTranscript,
-        inputs: impl IntoIterator<Item = impl IntoVrfInput<Self::H>>,
-        signature: &VrfSignature<Self,N>,
-    ) -> Result<[EcVrfInOut<Self>; N],Self::Error>
+        inputs: impl IntoIterator<Item = impl IntoVrfInput<EC<Self::Proof>>>,
+        signature: &VrfSignature<Self::Proof,N>,
+    ) -> Result<[IO<Self::Proof>; N],Self::Error>
     {
-        let ios: [EcVrfInOut<Self>; N] = signature.attach_inputs(inputs);
+        let ios: [IO<Self::Proof>; N] = signature.attach_inputs(inputs);
         self.vrf_verify_detached(t,ios.as_slice(),&signature.proof) ?;
         Ok(ios)
     }
@@ -113,9 +234,9 @@ pub trait EcVrfVerifier {
     fn vrf_verify_vec(
         &self,
         t: impl IntoTranscript,
-        inputs: impl IntoIterator<Item = impl IntoVrfInput<Self::H>>,
-        signature: &VrfSignatureVec<Self>,
-    ) -> Result<Vec<EcVrfInOut<Self>>,Self::Error>
+        inputs: impl IntoIterator<Item = impl IntoVrfInput<EC<Self::Proof>>>,
+        signature: &VrfSignatureVec<Self::Proof>,
+    ) -> Result<Vec<IO<Self::Proof>>,Self::Error>
     {
         let ios = signature.attach_inputs(inputs);
         self.vrf_verify_detached(t,ios.as_slice(),&signature.proof) ?;
@@ -123,165 +244,6 @@ pub trait EcVrfVerifier {
     }
 }
 
-impl<K: AffineRepr> EcVrfVerifier for (&crate::ThinVrf<K>,&crate::PublicKey<K>) {
-    type H = K;
-    type VrfProof = crate::Batchable<crate::ThinVrf<K>>;
-    type Error = error::SignatureError;
-    fn vrf_verify_detached<'a>(
-        &self,
-        t: impl IntoTranscript,
-        ios: &'a [EcVrfInOut<Self>],
-        signature: &EcVrfProof<Self>,
-    ) -> Result<&'a [EcVrfInOut<Self>],error::SignatureError>
-    {
-        self.0.verify_thin_vrf(t,ios,self.1,signature)
-    }
-}
-
-impl<K: AffineRepr> EcVrfVerifier for crate::PublicKey<K> {
-    type H = K;
-    type VrfProof = crate::Batchable<crate::ThinVrf<K>>;
-    type Error = error::SignatureError;
-    fn vrf_verify_detached<'a>(
-        &self,
-        t: impl IntoTranscript,
-        ios: &'a [EcVrfInOut<Self>],
-        signature: &EcVrfProof<Self>,
-    ) -> Result<&'a [EcVrfInOut<Self>],error::SignatureError>
-    {
-        crate::ThinVrf::default().verify_thin_vrf(t,ios,self,signature)
-    }
-}
-
-impl<K: AffineRepr> crate::PublicKey<K> {
-    pub fn verify_thin_vrf<const N: usize>(
-        &self,
-        t: impl IntoTranscript,
-        inputs: impl IntoIterator<Item = impl IntoVrfInput<K>>,
-        signature: &VrfSignature<Self,N>,
-    ) -> Result<[VrfInOut<K>; N],error::SignatureError>
-    {
-        self.vrf_verify(t,inputs,signature)
-    }
-
-    pub fn verify_thin_vrf_vec(
-        &self,
-        t: impl IntoTranscript,
-        inputs: impl IntoIterator<Item = impl IntoVrfInput<K>>,
-        signature: &VrfSignatureVec<Self>,
-    ) -> Result<Vec<VrfInOut<K>>,error::SignatureError>
-    {
-        self.vrf_verify_vec(t,inputs,signature)
-    }
-}
-
-pub type EcVrfInput<V> = VrfInput<<V as EcVrfVerifier>::H>;
-pub type EcVrfPreOut<V> = VrfPreOut<<V as EcVrfVerifier>::H>;
-pub type EcVrfInOut<V> = VrfInOut<<V as EcVrfVerifier>::H>;
-pub type EcVrfProof<V> = <V as EcVrfVerifier>::VrfProof;
-
-#[derive(CanonicalSerialize,CanonicalDeserialize)]
-pub struct VrfSignature<V: EcVrfVerifier+?Sized, const N: usize> {
-    pub proof: EcVrfProof<V>,
-    pub preouts: [EcVrfPreOut<V>; N],
-}
-
-impl<V: EcVrfVerifier+?Sized, const N: usize> Clone for VrfSignature<V,N> {
-    fn clone(&self) -> Self {
-        VrfSignature {
-            proof: self.proof.clone(),
-            preouts: self.preouts.clone(),
-        }
-    }
-}
-
-impl<V: EcVrfVerifier+?Sized, const N: usize> fmt::Debug for VrfSignature<V,N> {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		write!(f, "VrfSignature {{ proof: {:?}, preouts: {:?} }}", &self.proof, &self.preouts)
-	}
-}
-
-impl<V: EcVrfVerifier+?Sized, const N: usize> Eq for VrfSignature<V,N> {}
-
-impl<V: EcVrfVerifier+?Sized, const N: usize> PartialEq for VrfSignature<V,N> {
-    fn eq(&self, other: &Self) -> bool {
-        self.proof == other.proof && self.preouts == other.preouts
-    }
-}
-
-impl<V: EcVrfVerifier+?Sized, const N: usize> VrfSignature<V,N> {
-    pub fn attach_inputs(
-        &self,
-        inputs: impl IntoIterator<Item = impl IntoVrfInput<V::H>>
-    ) -> [EcVrfInOut<V>; N]
-    {
-        let mut inputs = inputs.into_iter();
-        let mut preouts = self.preouts.iter().cloned();
-        let cb = |_| preouts.next().unwrap().attach_input(inputs.next().unwrap());
-        core::array::from_fn(cb)
-    }
-
-    pub fn vrf_verify( 
-        &self,
-        t: impl IntoTranscript,
-        inputs: impl IntoIterator<Item = impl IntoVrfInput<V::H>>,
-        public: &V,
-    ) -> Result<[EcVrfInOut<V>; N],V::Error>
-    {
-        public.vrf_verify(t,inputs,self)
-    }
-}
-
-#[derive(CanonicalSerialize,CanonicalDeserialize)]
-pub struct VrfSignatureVec<V: EcVrfVerifier+?Sized> {
-    pub proof: EcVrfProof<V>,
-    pub preouts: Vec<EcVrfPreOut<V>>,
-}
-
-impl<V: EcVrfVerifier+?Sized> Clone for VrfSignatureVec<V> {
-    fn clone(&self) -> Self {
-        VrfSignatureVec {
-            proof: self.proof.clone(),
-            preouts: self.preouts.clone(),
-        }
-    }
-}
-
-impl<V: EcVrfVerifier+?Sized> fmt::Debug for VrfSignatureVec<V> {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		write!(f, "VrfSignature {{ proof: {:?}, preouts: {:?} }}", &self.proof, &self.preouts)
-	}
-}
-
-impl<V: EcVrfVerifier+?Sized> Eq for VrfSignatureVec<V> {}
-
-impl<V: EcVrfVerifier+?Sized> PartialEq for VrfSignatureVec<V> {
-    fn eq(&self, other: &Self) -> bool {
-        self.proof == other.proof && self.preouts == other.preouts
-    }
-}
-
-impl<V: EcVrfVerifier+?Sized> VrfSignatureVec<V> {
-    pub fn attach_inputs(
-        &self,
-        inputs: impl IntoIterator<Item = impl IntoVrfInput<V::H>>
-    ) -> Vec<EcVrfInOut<V>>
-    {
-        self.preouts.iter().zip(inputs)
-        .map(|(preout,input)| preout.attach_input(input))
-        .collect()
-    }
-
-    pub fn vrf_verify(
-        &self,
-        t: impl IntoTranscript,
-        inputs: impl IntoIterator<Item = impl IntoVrfInput<V::H>>,
-        public: &V,
-    ) -> Result<Vec<EcVrfInOut<V>>,V::Error>
-    {
-        public.vrf_verify_vec(t,inputs,self)
-    }
-}
 
 /// VRF signer, includes the secret key, but sometimes the ring opening too.
 /// 
@@ -300,31 +262,28 @@ impl<V: EcVrfVerifier+?Sized> VrfSignatureVec<V> {
 /// Inherent methods and other traits being used here:
 /// `IntoTranscript`, `vrf::{VrfInOut, VrfPreOut}`
 pub trait EcVrfSigner: Borrow<Self::Secret> {
-    /// Verifier type
-    /// 
-    /// We only fetch `V::H` and `V::VrfProof` via this, so if your
-    /// verifier contains lifetimes then approximate them by `'static`.
-    type V: EcVrfVerifier;
+    /// Detached signature aka proof type created by the VRF
+    type Proof: EcVrfProof;
 
     /// Signer failures, usually `!` but otherwise for ring VRFs
     type Error;  // = !;
 
     /// Actual secret key type, possible `Self` for regular VRFs
     /// but not for ring VRFs or simlar.
-    type Secret: EcVrfSecret<<Self::V as EcVrfVerifier>::H>;
+    type Secret: EcVrfSecret<EC<Self::Proof>>;
 
     fn vrf_sign_detached(
         &self,
         t: impl IntoTranscript,
-        ios: &[EcVrfInOut<Self::V>]
-    ) -> Result<EcVrfProof<Self::V>,Self::Error>;
+        ios: &[IO<Self::Proof>]
+    ) -> Result<Self::Proof,Self::Error>;
 
     /// VRF signature for a fixed number of input-output pairs
     fn vrf_sign<const N: usize>(
         &self,
         t: impl IntoTranscript,
-        ios: &[EcVrfInOut<Self::V>; N]
-    ) -> Result<VrfSignature<Self::V,N>,Self::Error>
+        ios: &[IO<Self::Proof>; N]
+    ) -> Result<VrfSignature<Self::Proof,N>,Self::Error>
     {
         let proof = self.vrf_sign_detached(t,ios) ?;
         let preouts = core::array::from_fn(|i| ios[i].preoutput.clone());
@@ -337,11 +296,11 @@ pub trait EcVrfSigner: Borrow<Self::Secret> {
     /// more for pedagogy than for convenience.  It demonstrates choosing
     /// whether we sign the VRF, and what else we sign in its transcript,
     /// after examining the VRF output.
-    fn vrf_sign_one<I,T,F>(&self, input: I, mut check: F) -> Result<VrfSignature<Self::V,1>,Self::Error>
+    fn vrf_sign_one<I,T,F>(&self, input: I, mut check: F) -> Result<VrfSignature<Self::Proof,1>,Self::Error>
     where
-        I: IntoVrfInput<<Self::V as EcVrfVerifier>::H>,
+        I: IntoVrfInput<EC<Self::Proof>>,
         T: IntoTranscript,
-        F: FnMut(&EcVrfInOut<Self::V>) -> Result<T,Self::Error>,
+        F: FnMut(&IO<Self::Proof>) -> Result<T,Self::Error>,
     {
         let io = self.borrow().vrf_inout(input);
         let t = check(&io) ?;
@@ -352,8 +311,8 @@ pub trait EcVrfSigner: Borrow<Self::Secret> {
     fn vrf_sign_vec(
         &self,
         t: impl IntoTranscript,
-        ios: &[EcVrfInOut<Self::V>]
-    ) -> Result<VrfSignatureVec<Self::V>,Self::Error>
+        ios: &[IO<Self::Proof>]
+    ) -> Result<VrfSignatureVec<Self::Proof>,Self::Error>
     {
         let proof = self.vrf_sign_detached(t,ios) ?;
         let preouts = ios.iter().map(|io| io.preoutput.clone()).collect();
@@ -361,46 +320,3 @@ pub trait EcVrfSigner: Borrow<Self::Secret> {
     }
 }
 
-impl<K: AffineRepr> EcVrfSigner for SecretKey<K> {
-    type V = crate::PublicKey<K>;
-    type Error = ();
-    type Secret = Self;
-    fn vrf_sign_detached(
-        &self,
-        t: impl IntoTranscript,
-        ios: &[EcVrfInOut<Self::V>]
-    ) -> Result<EcVrfProof<Self::V>,()>
-    {
-        Ok(self.sign_thin_vrf_detached(t,ios))
-    }
-}
-
-impl<K: AffineRepr> SecretKey<K> {
-    pub fn sign_thin_vrf<const N: usize>(
-        &self,
-        t: impl IntoTranscript,
-        ios: &[VrfInOut<K>; N]
-    ) -> VrfSignature<crate::PublicKey<K>,N>
-    {
-        self.vrf_sign(t,ios).unwrap() // "Infalible"
-    }
-
-    pub fn sign_thin_vrf_one<I,T,F>(&self, input: I, check: F)
-     -> Result<VrfSignature<crate::PublicKey<K>,1>,()>
-    where
-        I: IntoVrfInput<K>,
-        T: IntoTranscript,
-        F: FnMut(&VrfInOut<K>) -> Result<T,()>,
-    {
-        self.vrf_sign_one(input,check)
-    }
-
-    pub fn sign_thin_vrf_vec(
-        &self,
-        t: impl IntoTranscript,
-        ios: &[VrfInOut<K>]
-    ) -> VrfSignatureVec<crate::PublicKey<K>>
-    {
-        self.vrf_sign_vec(t,ios).unwrap() // "Infalible"
-    }
-}


### PR DESCRIPTION
Closes #59 

Roughly https://github.com/w3f/ring-vrf/pull/60 but associated types instead of type parameters 