### PR TITLE
Crates.io arkworks-substrate versions are broken.

### DIFF
--- a/bandersnatch_vrfs/Cargo.toml
+++ b/bandersnatch_vrfs/Cargo.toml
@@ -31,8 +31,8 @@ sha2 = { version = "0.10", default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }
 
 # Substrate curves are optional and gated by the 'substrate-curves' feature
-sp-ark-ed-on-bls12-381-bandersnatch = { version = "0.4.1", default-features = false, optional = true }
-sp-ark-bls12-381 = { version = "0.4.1", default-features = false, optional = true }
+sp-ark-ed-on-bls12-381-bandersnatch = { git = "https://github.com/paritytech/arkworks-substrate", default-features = false, optional = true }
+sp-ark-bls12-381 = { git = "https://github.com/paritytech/arkworks-substrate", default-features = false, optional = true }
 
 [features]
 default = ["std"]

--- a/bandersnatch_vrfs/src/lib.rs
+++ b/bandersnatch_vrfs/src/lib.rs
@@ -327,7 +327,7 @@ mod tests {
         
         let signature: RingVrfSignature<1> = RingProver {
             ring_prover: &ring_prover, secret,
-        }.sign_ring_vrf(transcript.clone(), &[io]);
+        }.sign_ring_vrf(transcript, &[io]);
         
         // TODO: serialize signature
 

--- a/bandersnatch_vrfs/src/ring.rs
+++ b/bandersnatch_vrfs/src/ring.rs
@@ -11,7 +11,6 @@ use ark_serialize::{
 use merlin::Transcript;
 
 use fflonk::pcs::PCS;
-use rand_core::RngCore;
 use ring::Domain;
 
 use crate::bandersnatch::{Fq, SWConfig, SWAffine};  // Fr


### PR DESCRIPTION
But I just noticed that the version on `crates.io` is not no-std compatible.

We need a new release to start using crates.io. For the moment resort to git

Sorry for the dance :-) 