### PR TITLE
Switch to a branch temporarily

### DIFF
--- a/bandersnatch_vrfs/Cargo.toml
+++ b/bandersnatch_vrfs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bandersnatch_vrfs"
 description = "Ring VRFs and thin VRF on bandersnatch"
 authors = ["Jeff Burdges <jeff@web3.foundation>"]
-version = "0.0.3"
+version = "0.0.4"
 repository = "https://github.com/w3f/ring-vrf/tree/master/bandersnatch_vrfs"
 edition = "2021"
 license = "MIT/Apache-2.0"
@@ -20,7 +20,7 @@ ark-ec.workspace = true
 ark-serialize.workspace = true
 
 fflonk = { git = "https://github.com/w3f/fflonk" }
-ring = { git = "https://github.com/w3f/ring-proof" }
+ring = { git = "https://github.com/burdges/ring-proof", branch="patch-1" }
 
 merlin = { version = "3.0", default-features = false }
 


### PR DESCRIPTION
We need not merge this if https://github.com/w3f/ring-proof/pull/15 gets merged, or similar like a getter method.

Fixes https://github.com/w3f/ring-proof/commit/d6bd529b9d08d2c11dfe0495556932be28dbf3bf#diff-d9afcebbe3d5a30f85085cf7ce661ad8f581ae8412b4df7e3a884ff9ccbdb472R20 caused by https://github.com/w3f/ring-proof/pull/13

cc https://github.com/paritytech/polkadot-sdk/issues/2327