### PR TITLE
getrandom_or_panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 [workspace.dependencies]
 
 rand_core = { version = "0.6", default-features = false }
-getrandom_or_panic = { version = "0.0.2", default-features = false }
+getrandom_or_panic = { version = "0.0.3", default-features = false }
 digest = { version = "0.10", default-features = false }
 # sha2 = { version = "0.10", default-features = false }
 # sha3 = { version = "0.10", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
 [workspace.dependencies]
 
 rand_core = { version = "0.6", default-features = false }
+getrandom_or_panic = { version = "0.0.2", default-features = false }
 digest = { version = "0.10", default-features = false }
 # sha2 = { version = "0.10", default-features = false }
 # sha3 = { version = "0.10", default-features = false }

--- a/ark-secret-scalar/Cargo.toml
+++ b/ark-secret-scalar/Cargo.toml
@@ -10,7 +10,6 @@ keywords = ["crypto", "cryptography", "vrf", "signature", "proof", "zkp", "priva
 
 
 [dependencies]
-rand_core.workspace = true
 getrandom_or_panic.workspace = true
 
 # TODO:  Add a std feature which activates thread_rng
@@ -35,7 +34,8 @@ ark-transcript = { version = "0.0.2", default-features = false, path = "../ark-t
 
 [features]
 default = ["getrandom"]  # "std"
-getrandom = ["rand_core/getrandom", "getrandom_or_panic/getrandom"]
+std = ["getrandom_or_panic/std"]
+getrandom = ["getrandom_or_panic/getrandom"]
 
 
 

--- a/ark-secret-scalar/Cargo.toml
+++ b/ark-secret-scalar/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["crypto", "cryptography", "vrf", "signature", "proof", "zkp", "priva
 
 [dependencies]
 rand_core.workspace = true
+getrandom_or_panic.workspace = true
 
 # TODO:  Add a std feature which activates thread_rng
 # rand = { version = "0.8", default-features = false }
@@ -34,7 +35,7 @@ ark-transcript = { version = "0.0.2", default-features = false, path = "../ark-t
 
 [features]
 default = ["getrandom"]  # "std"
-getrandom = ["rand_core/getrandom"]
+getrandom = ["rand_core/getrandom", "getrandom_or_panic/getrandom"]
 
 
 

--- a/ark-secret-scalar/src/lib.rs
+++ b/ark-secret-scalar/src/lib.rs
@@ -12,40 +12,13 @@ use ark_ff::{PrimeField}; // Field, Zero
 use ark_ec::{AffineRepr, Group}; // CurveGroup
 
 use digest::{XofReader};
-use rand_core::{RngCore,CryptoRng};
+pub use getrandom_or_panic::{RngCore,CryptoRng,rand_core,getrandom_or_panic};
 // use subtle::{Choice,ConstantTimeEq};
 use zeroize::Zeroize;
 
 // TODO:  Remove ark-transcript dependency once https://github.com/arkworks-rs/algebra/pull/643 lands
 use ark_transcript::xof_read_reduced;
 
-
-/// Returns `OsRng` with `getrandom`, or a `CryptoRng` which panics without `getrandom`.
-#[cfg(feature = "getrandom")] 
-pub fn getrandom_or_panic() -> impl RngCore+CryptoRng {
-    rand_core::OsRng
-}
-
-/// Returns `OsRng` with `getrandom`, or a `CryptoRng` which panics without `getrandom`.
-#[cfg(not(feature = "getrandom"))]
-pub fn getrandom_or_panic() -> impl RngCore+CryptoRng {
-    const PRM: &'static str = "Attempted to use functionality that requires system randomness!!";
-
-    // Should we panic when invoked or when used?
-
-    struct PanicRng;
-    impl rand_core::RngCore for PanicRng {
-        fn next_u32(&mut self) -> u32 {  panic!("{}", PRM)  }
-        fn next_u64(&mut self) -> u64 {  panic!("{}", PRM)  }
-        fn fill_bytes(&mut self, _dest: &mut [u8]) {  panic!("{}", PRM)  }
-        fn try_fill_bytes(&mut self, _dest: &mut [u8]) -> Result<(), rand_core::Error> {
-            Err(core::num::NonZeroU32::new(core::u32::MAX).unwrap().into())
-        }
-    }
-    impl rand_core::CryptoRng for PanicRng {}
-
-    PanicRng
-}
 
 
 pub struct Rng2Xof<R: RngCore+CryptoRng>(pub R);

--- a/bandersnatch_vrfs/Cargo.toml
+++ b/bandersnatch_vrfs/Cargo.toml
@@ -46,7 +46,7 @@ std = [
   "sp-ark-ed-on-bls12-381-bandersnatch?/std",
   "sp-ark-bls12-381?/std",
 ]
-getrandom = ["dleq_vrf/getrandom"]
+getrandom = ["dleq_vrf/getrandom"] # "ring/getrandom"]
 print-trace = ["ark-std/print-trace"]
 # Substrate curves allows to offload computationally heavy tasks to Substrate host functions.
 # Mostly useful in Substrate development context when targeting wasm32 architecture.

--- a/bandersnatch_vrfs/src/lib.rs
+++ b/bandersnatch_vrfs/src/lib.rs
@@ -243,7 +243,12 @@ impl<'a> RingProver<'a> {
 }
 
 
-#[cfg(test)]
+// TODO:  Run test vector tests once we have some even without getrandom
+// #[cfg(test)]
+// mod testvectors {
+// }
+
+#[cfg(all(test, feature = "getrandom"))]
 mod tests {
     use super::*;
     use core::iter;

--- a/dleq_vrf/Cargo.toml
+++ b/dleq_vrf/Cargo.toml
@@ -13,7 +13,6 @@ keywords = ["crypto", "cryptography", "vrf", "signature", "proof", "zkp", "priva
 # arrayref = { version = "0.3", default-features = false }
 arrayvec = { version = "0.7.2", default-features = false }
 
-rand_core.workspace = true
 zeroize.workspace = true
 
 ark-std.workspace = true
@@ -36,6 +35,7 @@ ark-bls12-377 = { version = "0.4", default-features = false, features = [ "curve
 
 [features]
 default = ["getrandom"]  #  "std", "rand"
-getrandom = ["rand_core/getrandom", "ark-secret-scalar/getrandom"]  #  "ark_transcript/getrandom"
+std = ["ark-secret-scalar/std"] # "rand_core/std"
+getrandom = ["ark-secret-scalar/getrandom"]  #  "ark_transcript/getrandom", "rand_core/getrandom", "getrandom_or_panic/getrandom"
 scale = ["dep:ark-scale"]
 

--- a/dleq_vrf/src/keys.rs
+++ b/dleq_vrf/src/keys.rs
@@ -3,7 +3,6 @@
 //! ### VRF keys
 
 
-use rand_core::{RngCore}; // CryptoRng
 use zeroize::Zeroize;
 
 use ark_std::{vec::Vec, io::{Read, Write}};
@@ -13,11 +12,12 @@ use ark_std::{vec::Vec, io::{Read, Write}};
 use ark_ec::{AffineRepr}; // Group, CurveGroup
 use ark_serialize::{CanonicalSerialize,CanonicalDeserialize,SerializationError};
 
-use ark_secret_scalar::SecretScalar;
+use ark_secret_scalar::{SecretScalar,RngCore,rand_core}; // CryptoRng
 
 use crate::{
     ThinVrf,
     transcript::digest::{Update,XofReader},
+
 };
 
 

--- a/nugget_bls/Cargo.toml
+++ b/nugget_bls/Cargo.toml
@@ -31,8 +31,10 @@ sha2 = { version = "0.10", default-features = false, optional = true }
 
 
 [features]
-default = ["getrandom", "bls12_381", "bls12_377"] # "std", "rand"
+default = ["std", "getrandom", "bls12_381", "bls12_377"]
+std = ["dleq_vrf/std", "rand_core/std"]
 bls12_377 = ["dep:ark-bls12-377", "dep:sha2"]
 bls12_381 = ["dep:ark-bls12-381", "dep:sha2"]
-getrandom = ["dleq_vrf/getrandom"]
+getrandom = ["dleq_vrf/getrandom", "rand_core/getrandom"]
 scale = ["dleq_vrf/scale", "dep:ark-scale"] 
+


### PR DESCRIPTION
We move getrandom_or_panic out of the repository to https://github.com/burdges/getrandom_or_panic so that it can be used from ring-proof.  Appears fflonk only uses test_rng in tests.

I believe this works since it passes schnorrkel CI now https://github.com/w3f/schnorrkel/pull/98 but it obviously makes it easier to have versions diverge.