### PR TITLE
EcVrfSigner trait support consumable preproofs

### DIFF
--- a/bandersnatch_vrfs/src/lib.rs
+++ b/bandersnatch_vrfs/src/lib.rs
@@ -218,12 +218,12 @@ impl<'a> EcVrfSigner for RingProver<'a> {
     type Error = ();
     type Secret = SecretKey;
     fn vrf_sign_detached(
-        &self,
+        self,
         t: impl IntoTranscript,
         ios: &[VrfInOut]
     ) -> Result<RingVrfProof,()>
     {
-        let RingProver { ring_prover, secret } = *self;
+        let RingProver { ring_prover, secret } = self;
         let secret_blinding = None; // TODO: Set this first so we can hash the ring proof
         let (dleq_proof,secret_blinding) = pedersen_vrf().sign_pedersen_vrf(t, ios, secret_blinding, secret);
         let ring_proof = ring_prover.prove(secret_blinding.0[0]);
@@ -233,7 +233,7 @@ impl<'a> EcVrfSigner for RingProver<'a> {
 
 impl<'a> RingProver<'a> {
     pub fn sign_ring_vrf<const N: usize>(
-        &self,
+        self,
         t: impl IntoTranscript,
         ios: &[VrfInOut; N],
     ) -> RingVrfSignature<N>

--- a/dleq_vrf/src/thin.rs
+++ b/dleq_vrf/src/thin.rs
@@ -245,12 +245,12 @@ impl<K: AffineRepr> PublicKey<K> {
     }
 }
 
-impl<K: AffineRepr> EcVrfSigner for SecretKey<K> {
+impl<K: AffineRepr> EcVrfSigner for &SecretKey<K> {
     type Proof = ThinVrfProof<K>;
     type Error = ();
-    type Secret = Self;
+    type Secret = SecretKey<K>;
     fn vrf_sign_detached(
-        &self,
+        self,
         t: impl IntoTranscript,
         ios: &[VrfInOut<K>]
     ) -> Result<Self::Proof,()>

--- a/dleq_vrf/src/traits.rs
+++ b/dleq_vrf/src/traits.rs
@@ -261,7 +261,7 @@ pub trait EcVrfVerifier {
 /// 
 /// Inherent methods and other traits being used here:
 /// `IntoTranscript`, `vrf::{VrfInOut, VrfPreOut}`
-pub trait EcVrfSigner: Borrow<Self::Secret> {
+pub trait EcVrfSigner: Sized+Borrow<Self::Secret> {
     /// Detached signature aka proof type created by the VRF
     type Proof: EcVrfProof;
 
@@ -273,14 +273,14 @@ pub trait EcVrfSigner: Borrow<Self::Secret> {
     type Secret: EcVrfSecret<EC<Self::Proof>>;
 
     fn vrf_sign_detached(
-        &self,
+        self,
         t: impl IntoTranscript,
         ios: &[IO<Self::Proof>]
     ) -> Result<Self::Proof,Self::Error>;
 
     /// VRF signature for a fixed number of input-output pairs
     fn vrf_sign<const N: usize>(
-        &self,
+        self,
         t: impl IntoTranscript,
         ios: &[IO<Self::Proof>; N]
     ) -> Result<VrfSignature<Self::Proof,N>,Self::Error>
@@ -296,7 +296,7 @@ pub trait EcVrfSigner: Borrow<Self::Secret> {
     /// more for pedagogy than for convenience.  It demonstrates choosing
     /// whether we sign the VRF, and what else we sign in its transcript,
     /// after examining the VRF output.
-    fn vrf_sign_one<I,T,F>(&self, input: I, mut check: F) -> Result<VrfSignature<Self::Proof,1>,Self::Error>
+    fn vrf_sign_one<I,T,F>(self, input: I, mut check: F) -> Result<VrfSignature<Self::Proof,1>,Self::Error>
     where
         I: IntoVrfInput<EC<Self::Proof>>,
         T: IntoTranscript,
@@ -309,7 +309,7 @@ pub trait EcVrfSigner: Borrow<Self::Secret> {
 
     /// VRF signature for a variable number of input-output pairs.
     fn vrf_sign_vec(
-        &self,
+        self,
         t: impl IntoTranscript,
         ios: &[IO<Self::Proof>]
     ) -> Result<VrfSignatureVec<Self::Proof>,Self::Error>


### PR DESCRIPTION
We make the EcVrfSinger trait consume `self` instead of borrow `&self`, so then in future it can work on preprepared proof types, where the proof should be consumed and destroyed once used.