### PR TITLE
Make piop params constructor public

### DIFF
--- a/bandersnatch_vrfs/src/ring.rs
+++ b/bandersnatch_vrfs/src/ring.rs
@@ -28,7 +28,7 @@ pub type RingVerifier = ring::ring_verifier::RingVerifier<Fq, RealKZG, SWConfig>
 pub type ProverKey = ring::ProverKey<Fq, RealKZG, SWAffine>;
 pub type VerifierKey = ring::VerifierKey<Fq, RealKZG>;
 
-fn make_piop_params(domain_size: usize) -> PiopParams {
+pub fn make_piop_params(domain_size: usize) -> PiopParams {
     let domain = Domain::new(domain_size, true);
     let seed = ring::find_complement_point::<crate::bandersnatch::BandersnatchConfig>();
     PiopParams::setup(domain, crate::BLINDING_BASE, seed)


### PR DESCRIPTION
Just to avoid code duplication here: https://github.com/davxy/verifiable/blob/02efb22be3ed5e77a35d5a2081ba10b20b8ecee0/src/ring_vrf_impl.rs#L113