### PR TITLE
Introduce CI jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,50 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: '-D warnings'
+  RUST_BACKTRACE: 1
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: Build
+        run: cargo build --verbose
+
+  build-wasm32:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: wasm32-unknown-unknown
+      - name: Build
+        run: cargo build --verbose --no-default-features --target wasm32-unknown-unknown
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: Run tests
+        run: cargo test --release

--- a/ark-transcript/src/lib.rs
+++ b/ark-transcript/src/lib.rs
@@ -28,7 +28,7 @@ use digest::{Update,XofReader,ExtendableOutput};
 #[cfg(test)]
 mod tests;
 
-#[cfg(debug_assertions)]
+#[cfg(any(test, debug_assertions))]
 pub mod debug;
 
 /// Trascript labels.


### PR DESCRIPTION
`no-std` for target `wasm32-unknown-unknown` breaks too often and this is directly propagated to `polkadot-sdk` master.

As we currently don't have these crates on `crates.io` we should at least have some minimal check.

This PR introduces the following jobs:
- build
- test
- build for target wasm32

See also: https://github.com/w3f/ring-proof/pull/20 and https://github.com/w3f/ring-proof/pull/21