### PR TITLE
[DO NOT MERGE] Bandersnatch ad-hoc point compression PoC

### DIFF
--- a/bandersnatch_vrfs/Cargo.toml
+++ b/bandersnatch_vrfs/Cargo.toml
@@ -18,6 +18,7 @@ ark-std.workspace = true
 ark-ff.workspace = true
 ark-ec.workspace = true
 ark-serialize.workspace = true
+ark-scale.workspace = true
 
 fflonk = { git = "https://github.com/w3f/fflonk" }
 ring = { git = "https://github.com/w3f/ring-proof" }

--- a/bandersnatch_vrfs/src/lib.rs
+++ b/bandersnatch_vrfs/src/lib.rs
@@ -7,11 +7,15 @@
 pub mod ring;
 pub mod zcash_consts;
 
+use core::ops::Deref;
+
 use ark_ff::MontFp;
 use ark_ec::{
     AffineRepr, CurveGroup,
+    models::short_weierstrass::SWFlags
     // hashing::{HashToCurveError, curve_maps, map_to_curve_hasher::MapToCurveBasedHasher, HashToCurve},
 };
+use ark_serialize::Valid;
 use ark_std::vec::Vec;   // io::{Read, Write}
 
 pub use ark_serialize::{CanonicalSerialize, CanonicalDeserialize, SerializationError, Compress};
@@ -41,11 +45,11 @@ pub use dleq_vrf::{
     scale,
 };
 
-use bandersnatch::SWAffine as Jubjub;
+use bandersnatch::SWAffine;
 
-pub type VrfInput = dleq_vrf::vrf::VrfInput<Jubjub>;
-pub type VrfPreOut = dleq_vrf::vrf::VrfPreOut<Jubjub>;
-pub type VrfInOut = dleq_vrf::vrf::VrfInOut<Jubjub>;
+pub type VrfInput = dleq_vrf::vrf::VrfInput<SWAffine>;
+pub type VrfPreOut = dleq_vrf::vrf::VrfPreOut<SWAffine>;
+pub type VrfInOut = dleq_vrf::vrf::VrfInOut<SWAffine>;
 
 pub struct Message<'a> {
     pub domain: &'a [u8],
@@ -60,11 +64,11 @@ G1Projective,
 >;
 
 pub fn hash_to_bandersnatch_curve(domain: &[u8],message: &[u8]) -> Result<VrfInput,HashToCurveError> {
-    dleq_vrf::vrf::ark_hash_to_curve::<Jubjub,H2C>(domain,message)
+    dleq_vrf::vrf::ark_hash_to_curve::<SWAffine,H2C>(domain,message)
 }
 */
 
-impl<'a> IntoVrfInput<Jubjub> for Message<'a> {
+impl<'a> IntoVrfInput<SWAffine> for Message<'a> {
     fn into_vrf_input(self) -> VrfInput {
         // TODO: Add Elligator to Arkworks
         // hash_to_bandersnatch_curve(self.domain,self.message)
@@ -75,26 +79,26 @@ impl<'a> IntoVrfInput<Jubjub> for Message<'a> {
         t.append(self.domain);
         t.label(b"message");
         t.append(self.message);
-        let p: <Jubjub as AffineRepr>::Group = t.challenge(b"vrf-input").read_uniform();
+        let p: <SWAffine as AffineRepr>::Group = t.challenge(b"vrf-input").read_uniform();
         vrf::VrfInput( p.into_affine() )
     }
 }
 
-pub const BLINDING_BASE: Jubjub = {
+pub const BLINDING_BASE: SWAffine = {
     const X: bandersnatch::Fq = MontFp!("4956610287995045830459834427365747411162584416641336688940534788579455781570");
     const Y: bandersnatch::Fq = MontFp!("52360910621642801549936840538960627498114783432181489929217988668068368626761");
-    Jubjub::new_unchecked(X, Y)
+    SWAffine::new_unchecked(X, Y)
 };
 
 
-type ThinVrf = dleq_vrf::ThinVrf<Jubjub>;
+type ThinVrf = dleq_vrf::ThinVrf<SWAffine>;
 
 /// Then VRF configured by the G1 generator for signatures.
 pub fn thin_vrf() -> ThinVrf {
-    dleq_vrf::ThinVrf::default()  //  keying_base: Jubjub::generator()
+    dleq_vrf::ThinVrf::default()  //  keying_base: SWAffine::generator()
 }
 
-type PedersenVrf = dleq_vrf::PedersenVrf<Jubjub>;
+type PedersenVrf = dleq_vrf::PedersenVrf<SWAffine>;
 
 /// Pedersen VRF configured by the G1 generator for public key certs.
 pub fn pedersen_vrf() -> PedersenVrf {
@@ -102,24 +106,120 @@ pub fn pedersen_vrf() -> PedersenVrf {
 }
 
 
-pub type SecretKey = dleq_vrf::SecretKey<Jubjub>;
+pub type SecretKey = dleq_vrf::SecretKey<SWAffine>;
 
-pub const PUBLIC_KEY_LENGTH: usize = 33;
+pub const PUBLIC_KEY_LENGTH: usize = 32;
 pub type PublicKeyBytes = [u8; PUBLIC_KEY_LENGTH];
 
-pub type PublicKey = dleq_vrf::PublicKey<Jubjub>;
+pub struct PublicKey(dleq_vrf::PublicKey<SWAffine>);
 
-pub fn serialize_publickey(pk: &PublicKey) -> PublicKeyBytes {
-    let mut bytes = [0u8; PUBLIC_KEY_LENGTH];
-    pk.serialize_compressed(bytes.as_mut_slice())
-    .expect("Curve needs more than 33 bytes compressed!");
-    bytes
+use ark_scale::{
+    ArkScaleMaxEncodedLen,
+    impl_encode_via_ark, impl_decode_via_ark,
+    scale::{Encode, Decode, EncodeLike, MaxEncodedLen},
+};
+
+impl Encode for PublicKey {
+    impl_encode_via_ark!();
 }
 
-pub fn deserialize_publickey(reader: &[u8]) -> Result<PublicKey, SerializationError> {
-    PublicKey::deserialize_compressed(reader)
+impl Decode for PublicKey {
+    impl_decode_via_ark!();
 }
 
+impl EncodeLike for PublicKey {}
+
+impl MaxEncodedLen for PublicKey {
+    #[inline]
+    fn max_encoded_len() -> usize {
+        PublicKey(dleq_vrf::PublicKey(SWAffine::zero())).compressed_size()
+    }
+}
+
+impl ArkScaleMaxEncodedLen for PublicKey {
+    #[inline]
+    fn max_encoded_len(compress: Compress) -> usize {
+        PublicKey(dleq_vrf::PublicKey(SWAffine::zero())).serialized_size(compress)
+    }
+}
+
+
+fn point_encode(p: &SWAffine) -> [u8; 32] {
+	let mut ark_raw = [0_u8; 33];
+	p.serialize_compressed(ark_raw.as_mut_slice())
+		.expect("serialization length is constant and checked by test; qed");
+	let mut raw = [0_u8; 32];
+	raw.copy_from_slice(&ark_raw[..32]);
+	raw[31] |= ark_raw[32] & SWFlags::YIsNegative as u8;
+	raw
+}
+
+fn point_decode<T: CanonicalDeserialize>(raw: &[u8; 32]) -> Result<T, SerializationError> {
+	let mut ark_raw = [0_u8; 33];
+	ark_raw[..32].copy_from_slice(&raw[..]);
+	if ark_raw.iter().all(|&b| b == 0) {
+		ark_raw[32] |= SWFlags::PointAtInfinity as u8;
+	} else if ark_raw[31] & SWFlags::YIsNegative as u8 != 0 {
+		ark_raw[32] |= SWFlags::YIsNegative as u8;
+	}
+	ark_raw[31] &= 0x7f;
+	T::deserialize_compressed_unchecked(ark_raw.as_slice())
+}
+
+impl CanonicalSerialize for PublicKey {
+    fn serialize_with_mode<W: std::io::prelude::Write>(
+        &self,
+        mut writer: W,
+        compress: Compress,
+    ) -> Result<(), SerializationError> {
+        match compress {
+            Compress::Yes => {
+                let buf = point_encode(&self.0.0);
+                writer.write_all(&buf).map_err(|_| SerializationError::NotEnoughSpace)
+            }
+            Compress::No => self.0.serialize_with_mode(writer, compress)
+        }
+    }
+
+    fn serialized_size(&self, compress: Compress) -> usize {
+        match compress {
+            Compress::Yes => 32,
+            Compress::No => self.0.serialized_size(compress)
+        }
+    }
+}
+
+impl CanonicalDeserialize for PublicKey {
+    fn deserialize_with_mode<R: std::io::prelude::Read>(
+        mut reader: R,
+        compress: Compress,
+        validate: ark_serialize::Validate,
+    ) -> Result<Self, SerializationError> {
+        let inner = match compress {
+            Compress::Yes => {
+                let mut buf = [0_u8; 32];
+                reader.read_exact(&mut buf)?;
+                point_decode::<dleq_vrf::PublicKey<SWAffine>>(&buf)
+            }
+            Compress::No => dleq_vrf::PublicKey::deserialize_with_mode(reader, compress, validate)
+        }?;
+        Ok(PublicKey(inner))
+    }
+}
+
+impl Valid for PublicKey {
+    fn check(&self) -> Result<(), SerializationError> {
+        self.0.check()
+    }
+}
+
+impl Deref for PublicKey {
+    type Target = dleq_vrf::PublicKey<SWAffine>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 type ThinVrfProof = dleq_vrf::Batchable<ThinVrf>;
 
@@ -135,7 +235,7 @@ pub struct RingVrfProof {
 }
 
 impl dleq_vrf::EcVrfProof for RingVrfProof {
-    type H = Jubjub;
+    type H = SWAffine;
 }
 
 // TODO: Can you impl Debug+Eq+PartialEq for ring::RingProof please Sergey?  We'll then derive Debug.
@@ -192,7 +292,7 @@ impl RingVerifier<'_> {
     pub fn verify_ring_vrf<const N: usize>(
         &self,
         t: impl IntoTranscript,
-        inputs: impl IntoIterator<Item = impl IntoVrfInput<Jubjub>>,
+        inputs: impl IntoIterator<Item = impl IntoVrfInput<SWAffine>>,
         signature: &RingVrfSignature<N>,
     ) -> Result<[VrfInOut; N],SignatureError>
     {
@@ -252,26 +352,39 @@ mod tests {
     use core::iter;
     use ark_std::rand::RngCore;
 
+    pub fn serialize_publickey(pk: &PublicKey) -> [u8; 32] {
+        let mut bytes = [0u8; 32];
+        pk.serialize_compressed(bytes.as_mut_slice())
+            .expect("Curve needs more than 32 bytes compressed!");
+        bytes
+    }
+
+    pub fn deserialize_publickey(reader: &[u8]) -> PublicKey {
+        PublicKey::deserialize_compressed(reader).unwrap()
+    }
+
+
+
     #[test]
     fn check_blinding_base() {
         let mut t = b"Bandersnatch VRF blinding base".into_transcript();
-        let blinding_base: <Jubjub as AffineRepr>::Group = t.challenge(b"vrf-input").read_uniform();
+        let blinding_base: <SWAffine as AffineRepr>::Group = t.challenge(b"vrf-input").read_uniform();
         debug_assert_eq!(blinding_base.into_affine(), BLINDING_BASE);
     }
 
     #[test]
     fn good_max_encoded_len() {
         use dleq_vrf::scale::MaxEncodedLen;
-        assert_eq!(crate::PUBLIC_KEY_LENGTH, <PublicKey as MaxEncodedLen>::max_encoded_len());
+        assert_eq!(32, <PublicKey as MaxEncodedLen>::max_encoded_len());
     }
 
     #[test]
     fn thin_sign_verify() {
         let secret = SecretKey::from_seed(&[0; 32]);
-        let public = secret.to_public();
-        assert_eq!(public.compressed_size(), PUBLIC_KEY_LENGTH);
+        let public = PublicKey(secret.to_public());
+        assert_eq!(public.compressed_size(), 32);
         let public = serialize_publickey(&public);
-        let public = deserialize_publickey(&public).unwrap();
+        let public = deserialize_publickey(&public);
 
         let input = Message {
             domain: b"domain",
@@ -301,10 +414,10 @@ mod tests {
 		let keyset_size = usize::from_le_bytes(l) % keyset_size;
 
         // Gen a bunch of random public keys
-        let mut pks: Vec<_> = (0..keyset_size).map(|_| Jubjub::rand(&mut rng)).collect();
+        let mut pks: Vec<_> = (0..keyset_size).map(|_| SWAffine::rand(&mut rng)).collect();
         // Just select one index for the actual key we are for signing
         let secret_key_idx = keyset_size / 2;
-        pks[secret_key_idx] = pk.0.into();
+        pks[secret_key_idx] = pk.0.0.into();
 
         let prover_key = kzg.prover_key(pks.clone());
         let ring_prover = kzg.init_ring_prover(prover_key, secret_key_idx);
@@ -319,7 +432,7 @@ mod tests {
     fn ring_sign_verify() {
         let secret = & SecretKey::from_seed(&[0; 32]);
 
-        let (ring_prover, ring_verifier) = ring_test_init(secret.to_public());
+        let (ring_prover, ring_verifier) = ring_test_init(PublicKey(secret.to_public()));
         
         let input = Message {
             domain: b"domain",

--- a/bandersnatch_vrfs/src/lib.rs
+++ b/bandersnatch_vrfs/src/lib.rs
@@ -167,7 +167,7 @@ fn point_decode<T: CanonicalDeserialize>(raw: &[u8; 32]) -> Result<T, Serializat
 }
 
 impl CanonicalSerialize for PublicKey {
-    fn serialize_with_mode<W: std::io::prelude::Write>(
+    fn serialize_with_mode<W: ark_std::io::Write>(
         &self,
         mut writer: W,
         compress: Compress,
@@ -190,7 +190,7 @@ impl CanonicalSerialize for PublicKey {
 }
 
 impl CanonicalDeserialize for PublicKey {
-    fn deserialize_with_mode<R: std::io::prelude::Read>(
+    fn deserialize_with_mode<R: ark_std::io::Read>(
         mut reader: R,
         compress: Compress,
         validate: ark_serialize::Validate,

--- a/bandersnatch_vrfs/src/ring.rs
+++ b/bandersnatch_vrfs/src/ring.rs
@@ -13,9 +13,10 @@ use merlin::Transcript;
 use ring::Domain;
 use ring::ring::Ring;
 
-use crate::bandersnatch::{Fq, SWAffine, SWConfig, BandersnatchConfig};
-use crate::bls12_381::Bls12_381;
-use crate::bls12_381;
+use crate::{
+    bandersnatch::{Fq, SWAffine, SWConfig, BandersnatchConfig},
+    bls12_381::Bls12_381, bls12_381,
+};
 
 type RealKZG = fflonk::pcs::kzg::KZG<Bls12_381>;
 
@@ -33,19 +34,20 @@ pub type KzgVk = fflonk::pcs::kzg::params::RawKzgVerifierKey<Bls12_381>;
 
 pub type RingCommitment = Ring<bls12_381::Fr, Bls12_381, BandersnatchConfig>;
 
-// A point on Jubjub, not belonging to the prime order subgroup.
+// A point not belonging to the prime order subgroup.
+//
 // Used as the point to start summation from, as inf doesn't have an affine representation.
-const COMPLEMENT_POINT: crate::Jubjub = {
+const COMPLEMENT_POINT: SWAffine = {
     const X: Fq = Fq::ZERO;
     const Y: Fq = MontFp!("11982629110561008531870698410380659621661946968466267969586599013782997959645");
-    crate::Jubjub::new_unchecked(X, Y)
+    SWAffine::new_unchecked(X, Y)
 };
 
 // Just a point of an unknown dlog.
-pub(crate) const PADDING_POINT: crate::Jubjub = {
+pub(crate) const PADDING_POINT: SWAffine = {
     const X: Fq = MontFp!("25448400713078632486748382313960039031302935774474538965225823993599751298535");
     const Y: Fq = MontFp!("24382892199244280513693545286348030912870264650402775682704689602954457435722");
-    crate::Jubjub::new_unchecked(X, Y)
+    SWAffine::new_unchecked(X, Y)
 };
 
 pub fn make_piop_params(domain_size: usize) -> PiopParams {
@@ -200,7 +202,7 @@ mod tests {
 
     #[test]
     fn check_padding_point() {
-        let padding_point = ring::hash_to_curve::<crate::Jubjub>(b"w3f/ring-proof/common/padding");
+        let padding_point = ring::hash_to_curve::<SWAffine>(b"w3f/ring-proof/common/padding");
         assert_eq!(PADDING_POINT, padding_point);
     }
 }


### PR DESCRIPTION
This PR show how is possible to further compress Bandersnatch points down to 32 bytes.

Arkworks compressed points are encoded in 33 bytes as 1 byte is reserved for the `Flags` (tracks point at infinite and negative y). This is quite generic, but for bandersnatch we can do better.

Bandersnatch base field is defined as BLS12-381 scalar field (bandersnatch::Fq = BLS12-381::Fr)

Modulo value: `q = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001`

This means that  the most significant bit is always free and it could be used to encode the y sign.

---

Here I drafted a "dirty" PoC only for the PublicKey. But if it is a reasonable change I will:
- isolate serialization related code in a separate module
- implement it for all other stuff which contains an affine point (i.e. signature and pre-outputs)