### PR TITLE
[PoC] Compress all  bandersnatch points in 32 bytes

### DIFF
--- a/bandersnatch_vrfs/Cargo.toml
+++ b/bandersnatch_vrfs/Cargo.toml
@@ -54,4 +54,5 @@ substrate-curves = [
   "sp-ark-ed-on-bls12-381-bandersnatch",
   "sp-ark-bls12-381",
 ]
+tiny-compress = []
 # parallel = ["std", "ring/parallel"]  #  ["std", "rayon", "ark-std/parallel", "ark-ff/parallel", "ark-ec/parallel", "ark-poly/parallel"]

--- a/bandersnatch_vrfs/src/affine.rs
+++ b/bandersnatch_vrfs/src/affine.rs
@@ -1,6 +1,7 @@
 use ark_ff::MontFp;
 use ark_ec::{short_weierstrass::{self, SWCurveConfig, SWFlags}, CurveConfig};
 use ark_serialize::{Compress, Read, SerializationError, Validate, Write};
+use ark_std::vec::Vec;
 use crate::bandersnatch::{BandersnatchConfig as BandersnatchConfigBase, SWAffine as AffineBase, SWProjective as ProjectiveBase};
 
 pub const COMPRESSED_POINT_SIZE: usize = 32;

--- a/bandersnatch_vrfs/src/affine.rs
+++ b/bandersnatch_vrfs/src/affine.rs
@@ -111,14 +111,16 @@ mod tests {
     // We assume that the point encoded with all zeros is the point at infinity
     // and that there is no valid point encoded with all zeros which is not the
     // point at infinity. Double check this here.
+    //
+    // Be explicity with validation flag.
     #[test]
     fn assumptions_check() {
         let mut buf = [0_u8; 33];
-        let err = AffineBase::deserialize_compressed(buf.as_slice()).unwrap_err();
+        let err = AffineBase::deserialize_with_mode(buf.as_slice(), Compress::Yes, Validate::Yes).unwrap_err();
         assert!(matches!(err, SerializationError::InvalidData));
 
         buf[32] |= SWFlags::YIsNegative as u8;
-        let err = AffineBase::deserialize_compressed(buf.as_slice()).unwrap_err();
+        let err = AffineBase::deserialize_with_mode(buf.as_slice(), Compress::Yes, Validate::Yes).unwrap_err();
         assert!(matches!(err, SerializationError::InvalidData));
     }
 

--- a/bandersnatch_vrfs/src/affine.rs
+++ b/bandersnatch_vrfs/src/affine.rs
@@ -120,7 +120,7 @@ mod tests {
     // The point `p = (x = 0, y != 0)` is a valid point on the curve but it is not considered
     // valid (`p.check()` fails) as it has an order not equal to `BandersnatchConfig::ScalarField`.
     // 
-    // Be explicity with validation flag.
+    // Assess the backend assumptions (i.e. `BandersnatchConfig` which ships with arkworks).
     #[test]
     fn assumptions_check() {
         let mut buf = [0_u8; 33];
@@ -146,9 +146,7 @@ mod tests {
         // Checks that `p = (0, y)` is NOT in the subgroup with order defined by `BandersnatchConfig::ScalarField`.
         assert!(!p.is_in_correct_subgroup_assuming_on_curve());
         let p = p.clear_cofactor();
-        assert!(p.check().is_ok());
-
-        
+        assert!(p.check().is_ok());       
     }
 
     #[test]
@@ -162,7 +160,6 @@ mod tests {
         let e2 = BandersnatchAffine::deserialize_compressed(buf.as_slice()).unwrap();
         assert_eq!(e, e2);
         assert!(e2.is_zero());
-
         
         let mut p = BandersnatchAffine::rand(&mut rng);
         assert_eq!(p.compressed_size(), COMPRESSED_POINT_SIZE);

--- a/bandersnatch_vrfs/src/affine.rs
+++ b/bandersnatch_vrfs/src/affine.rs
@@ -1,0 +1,82 @@
+use ark_ff::MontFp;
+use ark_ec::{short_weierstrass::{self, SWCurveConfig, SWFlags}, CurveConfig};
+use ark_serialize::{Compress, Read, SerializationError, Validate, Write};
+use crate::bandersnatch::{BandersnatchConfig as BandersnatchConfigBase, SWAffine as AffineBase};
+
+pub const COMPRESSED_POINT_SIZE: usize = 32;
+
+pub type BandersnatchAffine = short_weierstrass::Affine<BandersnatchConfig>;
+
+#[derive(Clone, Default, PartialEq, Eq)]
+pub struct BandersnatchConfig;
+
+const SW_GENERATOR_X: <BandersnatchConfig as CurveConfig>::BaseField =
+    MontFp!("30900340493481298850216505686589334086208278925799850409469406976849338430199");
+
+const SW_GENERATOR_Y: <BandersnatchConfig as CurveConfig>::BaseField =
+    MontFp!("12663882780877899054958035777720958383845500985908634476792678820121468453298");
+
+impl CurveConfig for BandersnatchConfig {
+    type BaseField = <BandersnatchConfigBase as CurveConfig>::BaseField;
+    type ScalarField = <BandersnatchConfigBase as CurveConfig>::ScalarField;
+
+    const COFACTOR: &'static [u64] = <BandersnatchConfigBase as CurveConfig>::COFACTOR;
+    const COFACTOR_INV: Self::ScalarField = <BandersnatchConfigBase as CurveConfig>::COFACTOR_INV;
+}
+
+impl SWCurveConfig for BandersnatchConfig {
+    const COEFF_A: Self::BaseField = <BandersnatchConfigBase as SWCurveConfig>::COEFF_A;
+    const COEFF_B: Self::BaseField = <BandersnatchConfigBase as SWCurveConfig>::COEFF_B;
+    const GENERATOR: BandersnatchAffine = BandersnatchAffine::new_unchecked(SW_GENERATOR_X, SW_GENERATOR_Y);
+
+    fn serialize_with_mode<W: Write>(
+        item: &BandersnatchAffine,
+        mut writer: W,
+        compress: ark_serialize::Compress,
+    ) -> Result<(), SerializationError> {
+        let base = AffineBase::new_unchecked(item.x, item.y);
+        match compress {
+            Compress::Yes => {
+                let mut buf = [0_u8; 33];
+                BandersnatchConfigBase::serialize_with_mode(&base, buf.as_mut_slice(), compress)?;
+            	buf[31] |= buf[32] & SWFlags::YIsNegative as u8;
+                writer.write_all(&buf[..32]).map_err(|_| SerializationError::InvalidData)
+            }
+            Compress::No => {
+                BandersnatchConfigBase::serialize_with_mode(&base, writer, compress)
+            }
+        }
+    }
+
+    fn deserialize_with_mode<R: Read>(
+        mut reader: R,
+        compress: Compress,
+        validate: Validate,
+    ) -> Result<BandersnatchAffine, SerializationError> {
+        let base = match compress {
+            Compress::Yes => {
+                let mut buf = [0_u8; 33];
+                reader.read_exact(&mut buf[..32])?;
+	            if buf.iter().all(|&b| b == 0) {
+		            buf[32] |= SWFlags::PointAtInfinity as u8;
+            	} else if buf[31] & SWFlags::YIsNegative as u8 != 0 {
+            		buf[32] |= SWFlags::YIsNegative as u8;
+            	}
+            	buf[31] &= 0x7f;
+                BandersnatchConfigBase::deserialize_with_mode(buf.as_slice(), compress, validate)
+            }
+            Compress::No => {
+                BandersnatchConfigBase::deserialize_with_mode(reader, compress, validate)
+            }
+        }?;
+        Ok(BandersnatchAffine::new(base.x, base.y))
+    }
+
+    #[inline(always)]
+    fn serialized_size(compress: Compress) -> usize {
+        match compress {
+            Compress::Yes => 32,
+            Compress::No => BandersnatchConfigBase::serialized_size(compress),
+        }
+    }
+}

--- a/bandersnatch_vrfs/src/affine.rs
+++ b/bandersnatch_vrfs/src/affine.rs
@@ -106,7 +106,21 @@ mod tests {
     use ark_ec::AffineRepr;
     use ark_ff::UniformRand;
     use rand_core;
-    use ark_serialize::{CanonicalSerialize, CanonicalDeserialize};
+    use ark_serialize::{CanonicalSerialize, CanonicalDeserialize, SerializationError};
+
+    // We assume that the point encoded with all zeros is the point at infinity
+    // and that there is no valid point encoded with all zeros which is not the
+    // point at infinity. Double check this here.
+    #[test]
+    fn assumptions_check() {
+        let mut buf = [0_u8; 33];
+        let err = AffineBase::deserialize_compressed(buf.as_slice()).unwrap_err();
+        assert!(matches!(err, SerializationError::InvalidData));
+
+        buf[32] |= SWFlags::YIsNegative as u8;
+        let err = AffineBase::deserialize_compressed(buf.as_slice()).unwrap_err();
+        assert!(matches!(err, SerializationError::InvalidData));
+    }
 
     #[test]
     fn serialization_works() {

--- a/bandersnatch_vrfs/src/ring.rs
+++ b/bandersnatch_vrfs/src/ring.rs
@@ -13,7 +13,8 @@ use merlin::Transcript;
 use ring::Domain;
 use ring::ring::Ring;
 
-use crate::bandersnatch::{Fq, SWAffine, SWConfig, BandersnatchConfig};
+use crate::bandersnatch::Fq;
+use crate::{BandersnatchAffine, BandersnatchConfig};
 use crate::bls12_381::Bls12_381;
 use crate::bls12_381;
 
@@ -21,12 +22,12 @@ type RealKZG = fflonk::pcs::kzg::KZG<Bls12_381>;
 
 type PcsParams = fflonk::pcs::kzg::urs::URS<Bls12_381>;
 
-pub type PiopParams = ring::PiopParams<Fq, SWConfig>;
+pub type PiopParams = ring::PiopParams<Fq, BandersnatchConfig>;
 pub type RingProof = ring::RingProof<Fq, RealKZG>;
-pub type RingProver = ring::ring_prover::RingProver<Fq, RealKZG, SWConfig>;
-pub type RingVerifier = ring::ring_verifier::RingVerifier<Fq, RealKZG, SWConfig>;
+pub type RingProver = ring::ring_prover::RingProver<Fq, RealKZG, BandersnatchConfig>;
+pub type RingVerifier = ring::ring_verifier::RingVerifier<Fq, RealKZG, BandersnatchConfig>;
 
-pub type ProverKey = ring::ProverKey<Fq, RealKZG, SWAffine>;
+pub type ProverKey = ring::ProverKey<Fq, RealKZG, BandersnatchAffine>;
 pub type VerifierKey = ring::VerifierKey<Fq, RealKZG>;
 
 pub type KzgVk = fflonk::pcs::kzg::params::RawKzgVerifierKey<Bls12_381>;
@@ -35,17 +36,17 @@ pub type RingCommitment = Ring<bls12_381::Fr, Bls12_381, BandersnatchConfig>;
 
 // A point on Jubjub, not belonging to the prime order subgroup.
 // Used as the point to start summation from, as inf doesn't have an affine representation.
-const COMPLEMENT_POINT: crate::Jubjub = {
+const COMPLEMENT_POINT: crate::BandersnatchAffine = {
     const X: Fq = Fq::ZERO;
     const Y: Fq = MontFp!("11982629110561008531870698410380659621661946968466267969586599013782997959645");
-    crate::Jubjub::new_unchecked(X, Y)
+    BandersnatchAffine::new_unchecked(X, Y)
 };
 
 // Just a point of an unknown dlog.
-pub(crate) const PADDING_POINT: crate::Jubjub = {
+pub(crate) const PADDING_POINT: crate::BandersnatchAffine = {
     const X: Fq = MontFp!("25448400713078632486748382313960039031302935774474538965225823993599751298535");
     const Y: Fq = MontFp!("24382892199244280513693545286348030912870264650402775682704689602954457435722");
-    crate::Jubjub::new_unchecked(X, Y)
+    BandersnatchAffine::new_unchecked(X, Y)
 };
 
 pub fn make_piop_params(domain_size: usize) -> PiopParams {
@@ -128,11 +129,11 @@ impl KZG {
     }
     */
 
-    pub fn prover_key(&self, pks: Vec<SWAffine>) -> ProverKey {
+    pub fn prover_key(&self, pks: Vec<BandersnatchAffine>) -> ProverKey {
         ring::index(self.pcs_params.clone(), &self.piop_params, pks).0
     }
 
-    pub fn verifier_key(&self, pks: Vec<SWAffine>) -> VerifierKey {
+    pub fn verifier_key(&self, pks: Vec<BandersnatchAffine>) -> VerifierKey {
         ring::index(self.pcs_params.clone(), &self.piop_params, pks).1
     }
 
@@ -195,12 +196,12 @@ mod tests {
 
     #[test]
     fn check_complement_point() {
-        assert_eq!(COMPLEMENT_POINT, ring::find_complement_point::<crate::bandersnatch::BandersnatchConfig>());
+        assert_eq!(COMPLEMENT_POINT, ring::find_complement_point::<BandersnatchConfig>());
     }
 
     #[test]
     fn check_padding_point() {
-        let padding_point = ring::hash_to_curve::<crate::Jubjub>(b"w3f/ring-proof/common/padding");
+        let padding_point = ring::hash_to_curve::<BandersnatchAffine>(b"w3f/ring-proof/common/padding");
         assert_eq!(PADDING_POINT, padding_point);
     }
 }

--- a/dleq_vrf/src/vrf.rs
+++ b/dleq_vrf/src/vrf.rs
@@ -78,7 +78,7 @@ where C: AffineRepr, H2C: HashToCurve<<C as AffineRepr>::Group>,
 /// As a defense in depth, we suggest thin VRF usages hash their
 /// public, given some broken applications might do soft derivations
 /// anyways.
-#[derive(Debug,Copy,Clone,CanonicalSerialize)] // CanonicalDeserialize, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash
+#[derive(Debug,Copy,Clone,CanonicalSerialize, CanonicalDeserialize, PartialEq, Eq)] // Default, PartialOrd, Ord, Hash
 #[repr(transparent)]
 pub struct VrfInput<C: AffineRepr>(pub C);
 
@@ -166,7 +166,7 @@ pub fn collect_preoutputs_vec<C: AffineRepr>(ios: &[VrfInOut<C>]) -> Vec<VrfPreO
 /// VRF input and pre-output paired together, possibly unverified.
 ///
 /// 
-#[derive(Debug,Copy,Clone,CanonicalSerialize)] // CanonicalDeserialize, PartialEq,Eq, PartialOrd, Ord, Hash
+#[derive(Debug,Copy,Clone,CanonicalSerialize, CanonicalDeserialize, PartialEq, Eq)] // PartialOrd, Ord, Hash
 pub struct VrfInOut<C: AffineRepr> {
     /// VRF input point
     pub input: VrfInput<C>,


### PR DESCRIPTION
This is a more elegant and general approach wrt https://github.com/w3f/ring-vrf/pull/85
(gated by `tiny-compress` feature)

By defining our `SWCurveConfig` type we catch the serialization of every affine point in one place (this includes serialization of PublicKey, VrfInput, VrfPreOutput, Signature, ..).

---


Note that in the `SWCurveConfig` we overwrite the point multiplication functions to delegate to the ones defined by the bandersnatch implementation we're actually using (which may be Arkworks upstream or the one using the Substrate hooks)


---

⚠️ Assumption

- We don't use the `PointAtInfinity` flag
- We assume that the point encoded with all zeros is the point at infinity and that there is no valid point encoded with all zeros which is not the point at infinity (i.e. a point with x = 0 and y != 0)
- Double check this assumption with a test: https://github.com/davxy/ring-vrf/blob/ef5b08fd4d2cfc82799061a628e6c12ba4dcb30e/bandersnatch_vrfs/src/affine.rs#L118-L150
