### PR TITLE
Remove unsafe cell from SecretKey

### DIFF
--- a/ark-secret-scalar/Cargo.toml
+++ b/ark-secret-scalar/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ark-secret-scalar"
 description = "Secret scalars for non-constant-time fields and curves"
 authors = ["Jeff Burdges <jeff@web3.foundation>"]
-version = "0.0.2"
+version = "0.0.3"
 repository = "https://github.com/w3f/ring-vrf/tree/master/ark-secret-scalar"
 edition = "2021"
 license = "MIT/Apache-2.0"
@@ -27,9 +27,7 @@ ark-transcript = { version = "0.0.2", default-features = false, path = "../ark-t
 
 
 [dev-dependencies]
-
-# TODO:  Tests
-# ark-bls12-377 = { version = "0.4", default-features = false, features = [ "curve" ] }
+ark-bls12-377 = { version = "0.4", default-features = false, features = [ "curve" ] }
 
 
 [features]

--- a/ark-secret-scalar/src/lib.rs
+++ b/ark-secret-scalar/src/lib.rs
@@ -88,6 +88,7 @@ impl<F: PrimeField> SecretScalar<F> {
         SecretScalar(self.0.clone())
     }
 
+    /// Randomply resplit the secret in two components.
     pub fn resplit(&mut self) {
         let mut xof = Rng2Xof(getrandom_or_panic());
         let x = xof_read_reduced(&mut xof);
@@ -110,6 +111,7 @@ impl<F: PrimeField> SecretScalar<F> {
         (lhs[0] * rhs) + (lhs[1] * rhs)
     }
 
+    /// Get the secret scalar value by joining the two components.
     pub fn scalar(&self) -> F {
         self.0[0] + self.0[1]
     }

--- a/bandersnatch_vrfs/Cargo.toml
+++ b/bandersnatch_vrfs/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 keywords = ["crypto", "cryptography", "vrf", "signature", "privacy"]
 
 [dependencies]
-dleq_vrf = { version = "0.0.2", default-features = false, path = "../dleq_vrf", features = [ "scale" ] }
+dleq_vrf = { default-features = false, path = "../dleq_vrf", features = [ "scale" ] }
 
 rand_core.workspace = true
 zeroize.workspace = true

--- a/dleq_vrf/Cargo.toml
+++ b/dleq_vrf/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dleq_vrf"
 description = "VRFs from Chaum-Pedersen DLEQ proofs, usable in Ring VRFs"
 authors = ["Sergey Vasilyev <swasilyev@gmail.com>", "Jeff Burdges <jeff@web3.foundation>", "Syed Hosseini <syed@riseup.net>"]
-version = "0.0.2"
+version = "0.0.3"
 repository = "https://github.com/w3f/ring-vrf/tree/master/dleq_vrf"
 edition = "2021"
 license = "MIT/Apache-2.0"
@@ -20,8 +20,8 @@ ark-ff.workspace = true
 ark-ec.workspace = true
 ark-serialize.workspace = true
 
-ark-secret-scalar = { version = "0.0.2", default-features = false, path = "../ark-secret-scalar" }
-ark-transcript = { version = "0.0.2", default-features = false, path = "../ark-transcript" }
+ark-secret-scalar = { default-features = false, path = "../ark-secret-scalar" }
+ark-transcript = { default-features = false, path = "../ark-transcript" }
 
 ark-scale = { workspace = true, optional = true }
 

--- a/dleq_vrf/src/pedersen.rs
+++ b/dleq_vrf/src/pedersen.rs
@@ -9,6 +9,7 @@
 
 use ark_ff::PrimeField;
 use ark_ec::{AffineRepr, CurveGroup};
+use ark_secret_scalar::SecretScalar;
 use ark_serialize::{CanonicalSerialize,CanonicalDeserialize};
 use ark_std::{borrow::BorrowMut, vec::Vec};
 
@@ -322,8 +323,9 @@ where K: AffineRepr, H: AffineRepr<ScalarField = K::ScalarField>,
         for i in 0..B {
             blindings.push( k.blindings[i] + c * secret_blindings.0[i] );
         }
+        let secret = SecretScalar::from(&secret.key);
         let s = Scalars {
-            keying: k.keying + secret.key.mul_by_challenge(&c),
+            keying: k.keying + secret.mul_by_challenge(&c),
             blindings: blindings.into_inner().unwrap(),
         };
         k.zeroize();

--- a/dleq_vrf/src/traits.rs
+++ b/dleq_vrf/src/traits.rs
@@ -23,6 +23,7 @@
 //! a remote signer.
 
 
+use ark_secret_scalar::SecretScalar;
 use ark_std::{borrow::Borrow, fmt, vec::Vec};
 
 use ark_serialize::{CanonicalSerialize,CanonicalDeserialize}; // Valid
@@ -73,7 +74,8 @@ impl<H,K> EcVrfSecret<H> for SecretKey<K>
 where K: AffineRepr, H: AffineRepr<ScalarField = K::ScalarField>,
 {
     fn vrf_preout(&self, input: &VrfInput<H>) -> VrfPreOut<H> {
-        VrfPreOut( (&self.key * &input.0).into_affine() )
+        let secret = SecretScalar::from(&self.key);
+        VrfPreOut( (&secret * &input.0).into_affine() )
     }
 }
 

--- a/nugget_bls/Cargo.toml
+++ b/nugget_bls/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["crypto", "cryptography", "bls", "signature"]
 
 
 [dependencies]
-dleq_vrf = { version = "0.0.2", default-features = false, path = "../dleq_vrf" }
+dleq_vrf = { default-features = false, path = "../dleq_vrf" }
 
 rand_core.workspace = true
 zeroize.workspace = true


### PR DESCRIPTION
Instead of applying the resplit after the operation. Resplit **before** (by cloning where necessary).

This also allows the secret key to be `Sync`