### PR TITLE
Challenge in accumulation mode

### DIFF
--- a/ark-transcript/src/lib.rs
+++ b/ark-transcript/src/lib.rs
@@ -120,7 +120,11 @@ impl Mode {
         println!("Shake128 {}transcript XoF reader",self.debug_name);
         match self {
             Mode::Hash(hasher) => Reader(hasher.clone().finalize_xof()),
-            Mode::Accumulate(_) => panic!("Attempt to read from accumulating Transcript"),
+            Mode::Accumulate(acc) => {
+                let mut t = Transcript::from_accumulation(acc);
+                t.seperate();
+                t.mode.raw_reader()
+            }
         }
     }
 }

--- a/ark-transcript/src/tests.rs
+++ b/ark-transcript/src/tests.rs
@@ -104,3 +104,26 @@ fn accumulation() {
     let c2: [u8; 32] = t3.challenge(b"challenge").read_byte_array();
     assert_eq!(c1,c2);
 }
+
+#[test]
+fn challenge_in_accumulation() {
+    let mut t1 = Transcript::new_blank_accumulator();
+    let mut t2 = Transcript::new_blank_accumulator();
+
+    let commitment1 = b"commitment data 1";
+    let commitment2 = b"commitment data 2";
+
+    t1.write_bytes(commitment1);
+    t2.write_bytes(commitment1);
+
+    t1.write_bytes(commitment2);
+    t2.write_bytes(commitment2);
+
+    let acc = t2.accumulator_finalize();
+    let mut t3 = Transcript::from_accumulation(acc);
+
+    let c1: [u8; 32] = t1.challenge(b"challenge").read_byte_array();
+    let c2: [u8; 32] = t3.challenge(b"challenge").read_byte_array();
+
+    assert_eq!(c1, c2);
+}


### PR DESCRIPTION
DLEQ-vrf sign / verify functions take as input an object which implements `IntoTranscript` trait.

This means the user is free to construct and pass a transcript constructed via the `new_blank_accumulator`, which internally uses the `AccumulateMode`.

This prevents to panic and to correctly handle such a case