### PR TITLE
Fix ring params

### DIFF
--- a/bandersnatch_vrfs/src/ring.rs
+++ b/bandersnatch_vrfs/src/ring.rs
@@ -129,11 +129,11 @@ impl KZG {
     */
 
     pub fn prover_key(&self, pks: Vec<SWAffine>) -> ProverKey {
-        ring::index(self.pcs_params.clone(), &self.piop_params, pks).0
+        ring::index(&self.pcs_params, &self.piop_params, &pks).0
     }
 
     pub fn verifier_key(&self, pks: Vec<SWAffine>) -> VerifierKey {
-        ring::index(self.pcs_params.clone(), &self.piop_params, pks).1
+        ring::index(&self.pcs_params, &self.piop_params, &pks).1
     }
 
     /// `k` is the prover secret index in [0..keyset_size).


### PR DESCRIPTION
Got an error when try to build from master:

```rust
❯ cargo build -r
   Compiling bandersnatch_vrfs v0.0.4 (/Users/stepanlavrentev/ring-vrf/bandersnatch_vrfs)
error[E0308]: arguments to this function are incorrect
   --> bandersnatch_vrfs/src/ring.rs:132:9
    |
132 |         ring::index(self.pcs_params.clone(), &self.piop_params, pks).0
    |         ^^^^^^^^^^^
    |
note: expected `&_`, found `URS<Bls12<Config>>`
   --> bandersnatch_vrfs/src/ring.rs:132:21
    |
132 |         ring::index(self.pcs_params.clone(), &self.piop_params, pks).0
    |                     ^^^^^^^^^^^^^^^^^^^^^^^
    = note: expected reference `&_`
                  found struct `URS<Bls12<ark_bls12_381::Config>>`
note: expected `&[Affine<BandersnatchConfig>]`, found `Vec<Affine<BandersnatchConfig>>`
   --> bandersnatch_vrfs/src/ring.rs:132:65
    |
132 |         ring::index(self.pcs_params.clone(), &self.piop_params, pks).0
    |                                                                 ^^^
    = note: expected reference `&[ark_ec::short_weierstrass::Affine<BandersnatchConfig>]`
                  found struct `Vec<ark_ec::short_weierstrass::Affine<BandersnatchConfig>>`
note: function defined here
   --> /Users/stepanlavrentev/.cargo/git/checkouts/ring-proof-e9e49c3c86c409a2/665f5f5/ring/src/piop/mod.rs:222:8
    |
222 | pub fn index<F: PrimeField, CS: PCS<F>, Curve: SWCurveConfig<BaseField=F>>(
    |        ^^^^^
help: consider borrowing here
    |
132 |         ring::index(&self.pcs_params.clone(), &self.piop_params, pks).0
    |                     +
help: consider borrowing here
    |
132 |         ring::index(self.pcs_params.clone(), &self.piop_params, &pks).0
    |                                                                 +

error[E0308]: arguments to this function are incorrect
   --> bandersnatch_vrfs/src/ring.rs:136:9
    |
136 |         ring::index(self.pcs_params.clone(), &self.piop_params, pks).1
    |         ^^^^^^^^^^^
    |
note: expected `&_`, found `URS<Bls12<Config>>`
   --> bandersnatch_vrfs/src/ring.rs:136:21
    |
136 |         ring::index(self.pcs_params.clone(), &self.piop_params, pks).1
    |                     ^^^^^^^^^^^^^^^^^^^^^^^
    = note: expected reference `&_`
                  found struct `URS<Bls12<ark_bls12_381::Config>>`
note: expected `&[Affine<BandersnatchConfig>]`, found `Vec<Affine<BandersnatchConfig>>`
   --> bandersnatch_vrfs/src/ring.rs:136:65
    |
136 |         ring::index(self.pcs_params.clone(), &self.piop_params, pks).1
    |                                                                 ^^^
    = note: expected reference `&[ark_ec::short_weierstrass::Affine<BandersnatchConfig>]`
                  found struct `Vec<ark_ec::short_weierstrass::Affine<BandersnatchConfig>>`
note: function defined here
   --> /Users/stepanlavrentev/.cargo/git/checkouts/ring-proof-e9e49c3c86c409a2/665f5f5/ring/src/piop/mod.rs:222:8
    |
222 | pub fn index<F: PrimeField, CS: PCS<F>, Curve: SWCurveConfig<BaseField=F>>(
    |        ^^^^^
help: consider borrowing here
    |
136 |         ring::index(&self.pcs_params.clone(), &self.piop_params, pks).1
    |                     +
help: consider borrowing here
    |
136 |         ring::index(self.pcs_params.clone(), &self.piop_params, &pks).1
    |                                                                 +

For more information about this error, try `rustc --explain E0308`.
error: could not compile `bandersnatch_vrfs` (lib) due to 2 previous errors
```